### PR TITLE
fix(MessageList): update scroll behaviour

### DIFF
--- a/src/components/organisms/MessageList/MessageList.tsx
+++ b/src/components/organisms/MessageList/MessageList.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import type {OptionsType} from '@diplodoc/transform/lib/typings';
 
 import {useScrollPreservation, useSmartScroll} from '../../../hooks';
@@ -71,17 +69,13 @@ export function MessageList<TContent extends TMessageContent = never>({
 }: MessageListProps<TContent>) {
     const isStreaming = status === 'streaming';
     const isSubmitted = status === 'submitted';
-    const messagesCount = messages.length;
     const showLoader = status && loaderStatuses.includes(status);
 
-    const {containerRef, endRef, scrollToBottom} = useSmartScroll<HTMLDivElement>(
-        isStreaming,
-        messagesCount,
-    );
-
-    useEffect(() => {
-        scrollToBottom();
-    }, []);
+    const {containerRef, endRef} = useSmartScroll<HTMLDivElement>({
+        isStreaming: isStreaming || isSubmitted,
+        messagesCount: messages.length,
+        status,
+    });
 
     // Preserve scroll position when older messages are loaded
     useScrollPreservation(containerRef, messages.length);


### PR DESCRIPTION
**Summary**
Refactors auto-scroll logic in MessageList and useSmartScroll for better reliability.

**Changes**
`useSmartScroll` hook:
- Refactored to accept an options object instead of separate parameters
- Replaced useState with useRef for tracking user scroll state (reduces re-renders)
- Added status parameter support for scroll behavior on chat status changes
- Separated scroll effects for initial scroll, status changes, and message count changes

`MessageList` component:
- Updated useSmartScroll usage to pass options object with status
- Extended isStreaming condition to include isSubmitted status
- Removed redundant useEffect for initial scroll