### PR TITLE
feat(MarkdownRenderer): Add blocks memoization and parsing incomplete chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@bem-react/classname": "^1.7.0",
         "dayjs": "^1.11.19",
+        "marked": "^17.0.1",
         "react-window": "^2.2.1",
+        "remend": "^1.0.1",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -14347,6 +14349,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -16346,6 +16360,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/remend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.0.1.tgz",
+      "integrity": "sha512-152puVH0qMoRJQFnaMG+rVDdf01Jq/CaED+MBuXExurJgdbkLp0c3TIe4R12o28Klx8uyGsjvFNG05aFG69G9w==",
+      "license": "Apache-2.0"
     },
     "node_modules/renderkid": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
     "@babel/preset-typescript": "^7.28.5",
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
+    "@diplodoc/transform": "^4.63.3",
     "@gravity-ui/eslint-config": "^3.1.1",
+    "@gravity-ui/i18n": "^1.8.0",
+    "@gravity-ui/icons": "^2.16.0",
     "@gravity-ui/prettier-config": "^1.1.0",
     "@gravity-ui/stylelint-config": "^4.0.1",
     "@gravity-ui/tsconfig": "^1.0.0",
-    "@diplodoc/transform": "^4.63.3",
-    "@gravity-ui/i18n": "^1.8.0",
-    "@gravity-ui/icons": "^2.16.0",
     "@gravity-ui/uikit": "^7.25.0",
     "@playwright/experimental-ct-react": "^1.56.1",
     "@playwright/test": "^1.56.1",
@@ -118,13 +118,13 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
     "@diplodoc/transform": "^4.63.3",
     "@gravity-ui/i18n": "^1.8.0",
     "@gravity-ui/icons": "^2.16.0",
     "@gravity-ui/uikit": "^7.25.0",
-    "highlight.js": "^11.11.1"
+    "highlight.js": "^11.11.1",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "nano-staged": {
     "*.{scss}": [
@@ -140,7 +140,9 @@
   "dependencies": {
     "@bem-react/classname": "^1.7.0",
     "dayjs": "^1.11.19",
+    "marked": "^17.0.1",
     "react-window": "^2.2.1",
+    "remend": "^1.0.1",
     "uuid": "^13.0.0"
   }
 }

--- a/src/components/atoms/MarkdownRenderer/__stories__/MarkdownRenderer.stories.tsx
+++ b/src/components/atoms/MarkdownRenderer/__stories__/MarkdownRenderer.stories.tsx
@@ -1,11 +1,16 @@
+import {useEffect, useMemo, useRef, useState} from 'react';
+
 import type {
     ExtendedPluginWithCollect,
     MarkdownIt,
     OptionsType,
 } from '@diplodoc/transform/lib/typings';
-import {Meta, StoryFn} from '@storybook/react-webpack5';
+import {Meta, StoryFn, StoryObj} from '@storybook/react-webpack5';
 
 import {MarkdownRenderer, MarkdownRendererProps} from '..';
+import {ContentWrapper} from '../../../../demo/ContentWrapper';
+import {Showcase} from '../../../../demo/Showcase';
+import {ShowcaseItem} from '../../../../demo/ShowcaseItem';
 
 import MDXDocs from './Docs.mdx';
 
@@ -32,6 +37,16 @@ export default {
         },
     },
 } as Meta;
+
+type Story = StoryObj<typeof MarkdownRenderer>;
+
+const defaultDecorators = [
+    (Story) => (
+        <Showcase>
+            <Story />
+        </Showcase>
+    ),
+] satisfies Story['decorators'];
 
 export const Playground: StoryFn<MarkdownRendererProps> = (args) => <MarkdownRenderer {...args} />;
 Playground.args = {
@@ -64,4 +79,68 @@ export const WithTransformOptions: StoryFn<MarkdownRendererProps> = () => {
     const content = `# Custom Plugin Example\n\nThis is **bold text** with custom styling applied via plugin.`;
 
     return <MarkdownRenderer content={content} transformOptions={transformOptions} />;
+};
+
+const STREAMING_CONTENT = `**This is a very long bold text that keeps going and going without a clear end, so you can see how unterminated bold blocks are handled by the renderer.**
+
+*Here is an equally lengthy italicized sentence that stretches on and on, never quite reaching a conclusion, so you can observe how unterminated italic blocks behave in a streaming Markdown context, particularly when the content is verbose.*
+
+\`This is a long inline code block that should be unterminated and continues for quite a while, including some code-like content such as const foo = "bar"; and more, to see how the parser deals with it when the code block is not properly closed\`
+
+[This is a very long link text that is unterminated and keeps going to show how unterminated links are rendered in the preview, especially when the link text is verbose and the URL is missing or incomplete](https://gravity-ui.com/ru/libraries/aikit)`;
+
+function StreamingMarkdownComparison() {
+    const tokens = useMemo(() => STREAMING_CONTENT.split(''), []);
+    const [content, setContent] = useState('');
+    const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+
+        setContent('');
+        let currentContent = '';
+        let index = 0;
+
+        intervalRef.current = setInterval(() => {
+            if (index < tokens.length) {
+                currentContent += tokens[index];
+                setContent(currentContent);
+                index += 1;
+            }
+            if (index >= tokens.length && intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        }, 15);
+
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        };
+    }, [tokens]);
+
+    return (
+        <>
+            <ShowcaseItem title="Without shouldParseIncompleteMarkdown (default)">
+                <ContentWrapper width="400px">
+                    <MarkdownRenderer content={content} shouldParseIncompleteMarkdown={false} />
+                </ContentWrapper>
+            </ShowcaseItem>
+            <ShowcaseItem title="With shouldParseIncompleteMarkdown">
+                <ContentWrapper width="400px">
+                    <MarkdownRenderer content={content} shouldParseIncompleteMarkdown={true} />
+                </ContentWrapper>
+            </ShowcaseItem>
+        </>
+    );
+}
+
+export const WithParsingIncompleteMarkdown: StoryObj<typeof MarkdownRenderer> = {
+    render: () => <StreamingMarkdownComparison />,
+    decorators: defaultDecorators,
 };

--- a/src/components/organisms/AssistantMessage/AssistantMessage.tsx
+++ b/src/components/organisms/AssistantMessage/AssistantMessage.tsx
@@ -35,6 +35,7 @@ export type AssistantMessageProps<TContent extends TMessageContent = never> = Ba
     AssistantMessagePick<TContent> & {
         messageRendererRegistry?: MessageRendererRegistry;
         transformOptions?: OptionsType;
+        shouldParseIncompleteMarkdown?: boolean;
         className?: string;
         qa?: string;
     };
@@ -48,19 +49,23 @@ export function AssistantMessage<TContent extends TMessageContent = never>({
     id,
     messageRendererRegistry,
     transformOptions,
+    shouldParseIncompleteMarkdown,
     showActionsOnHover,
     showTimestamp,
     className,
     qa,
 }: AssistantMessageProps<TContent>) {
     const registry = useMemo<MessageRendererRegistry>(() => {
-        const defaultRegistry = createDefaultMessageRegistry(transformOptions);
+        const defaultRegistry = createDefaultMessageRegistry(
+            transformOptions,
+            shouldParseIncompleteMarkdown,
+        );
         if (messageRendererRegistry) {
             return mergeMessageRendererRegistries(defaultRegistry, messageRendererRegistry);
         }
 
         return defaultRegistry;
-    }, [messageRendererRegistry, transformOptions]);
+    }, [messageRendererRegistry, transformOptions, shouldParseIncompleteMarkdown]);
 
     const parts = normalizeContent<TContent>(content);
 

--- a/src/components/organisms/AssistantMessage/defaultMessageTypeRegistry.tsx
+++ b/src/components/organisms/AssistantMessage/defaultMessageTypeRegistry.tsx
@@ -16,12 +16,17 @@ import {ToolMessage} from '../ToolMessage';
 
 export function createDefaultMessageRegistry(
     transformOptions?: OptionsType,
+    shouldParseIncompleteMarkdown?: boolean,
 ): MessageRendererRegistry {
     const registry = createMessageRendererRegistry();
 
     registerMessageRenderer<TextMessageContent>(registry, 'text', {
         component: ({part}) => (
-            <MarkdownRenderer content={part.data.text} transformOptions={transformOptions} />
+            <MarkdownRenderer
+                content={part.data.text}
+                transformOptions={transformOptions}
+                shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
+            />
         ),
     });
 

--- a/src/components/organisms/MessageList/MessageList.tsx
+++ b/src/components/organisms/MessageList/MessageList.tsx
@@ -36,6 +36,7 @@ export type MessageListProps<TContent extends TMessageContent = never> = {
     onRetry?: () => void;
     messageRendererRegistry?: MessageRendererRegistry;
     transformOptions?: OptionsType;
+    shouldParseIncompleteMarkdown?: boolean;
     showActionsOnHover?: boolean;
     showTimestamp?: boolean;
     showAvatar?: boolean;
@@ -53,6 +54,7 @@ export function MessageList<TContent extends TMessageContent = never>({
     messages,
     messageRendererRegistry,
     transformOptions,
+    shouldParseIncompleteMarkdown,
     showActionsOnHover,
     showTimestamp,
     showAvatar,
@@ -93,6 +95,7 @@ export function MessageList<TContent extends TMessageContent = never>({
                     format={message.format}
                     avatarUrl={message.avatarUrl}
                     transformOptions={transformOptions}
+                    shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
                     showActionsOnHover={showActionsOnHover}
                     showTimestamp={showTimestamp}
                     showAvatar={showAvatar}
@@ -117,6 +120,7 @@ export function MessageList<TContent extends TMessageContent = never>({
                     id={message.id}
                     messageRendererRegistry={messageRendererRegistry}
                     transformOptions={transformOptions}
+                    shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
                     showActionsOnHover={showActionsOnHover}
                     showTimestamp={showTimestamp}
                 />

--- a/src/components/organisms/UserMessage/index.tsx
+++ b/src/components/organisms/UserMessage/index.tsx
@@ -20,6 +20,7 @@ export type UserMessageProps = Pick<
     showAvatar?: boolean;
     avatarUrl?: string;
     transformOptions?: OptionsType;
+    shouldParseIncompleteMarkdown?: boolean;
     className?: string;
     qa?: string;
 };
@@ -37,6 +38,7 @@ export const UserMessage = (props: UserMessageProps) => {
         showTimestamp,
         format = 'plain',
         transformOptions,
+        shouldParseIncompleteMarkdown,
     } = props;
 
     return (
@@ -54,6 +56,7 @@ export const UserMessage = (props: UserMessageProps) => {
                         <MarkdownRenderer
                             content={content as string}
                             transformOptions={transformOptions}
+                            shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
                         />
                     ) : (
                         content

--- a/src/components/pages/ChatContainer/ChatContainer.tsx
+++ b/src/components/pages/ChatContainer/ChatContainer.tsx
@@ -35,6 +35,7 @@ export function ChatContainer(props: ChatContainerProps) {
         showActionsOnHover = false,
         contextItems = [],
         transformOptions,
+        shouldParseIncompleteMarkdown,
         messageListConfig,
         headerProps = {},
         contentProps = {},
@@ -143,8 +144,18 @@ export function ChatContainer(props: ChatContainerProps) {
             onRetry,
             showActionsOnHover,
             transformOptions,
+            shouldParseIncompleteMarkdown,
         }),
-        [messages, status, error, onRetry, showActionsOnHover, transformOptions, messageListConfig],
+        [
+            messages,
+            status,
+            error,
+            onRetry,
+            showActionsOnHover,
+            transformOptions,
+            shouldParseIncompleteMarkdown,
+            messageListConfig,
+        ],
     );
 
     // Build props for PromptInput

--- a/src/components/pages/ChatContainer/types.ts
+++ b/src/components/pages/ChatContainer/types.ts
@@ -143,6 +143,8 @@ export interface ChatContainerProps {
     contextItems?: ContextItemConfig[];
     /** Transform options for markdown rendering */
     transformOptions?: OptionsType;
+    /** Should parse incomplete markdown (e.g., during streaming) */
+    shouldParseIncompleteMarkdown?: boolean;
 
     // Configuration
     /** MessageList configuration for actions and loader behavior */

--- a/src/hooks/useMarkdownTransform.ts
+++ b/src/hooks/useMarkdownTransform.ts
@@ -1,0 +1,56 @@
+import {useMemo, useRef} from 'react';
+
+import transform from '@diplodoc/transform';
+import '@diplodoc/transform/dist/js/yfm';
+import {OptionsType} from '@diplodoc/transform/lib/typings';
+
+import {areOptionsEqual} from '../utils/markdownUtils';
+import {parseMarkdownIntoBlocks} from '../utils/parse-blocks';
+
+export function useMarkdownTransform(content: string, options?: OptionsType): string {
+    const cacheRef = useRef<Map<string, string>>(new Map());
+    const prevOptionsRef = useRef<OptionsType | undefined>(options);
+
+    return useMemo(() => {
+        if (!content) {
+            return '';
+        }
+
+        const optionsChanged = !areOptionsEqual(prevOptionsRef.current, options);
+        if (optionsChanged) {
+            cacheRef.current.clear();
+            prevOptionsRef.current = options;
+        }
+
+        try {
+            const blocks = parseMarkdownIntoBlocks(content);
+            const cache = cacheRef.current;
+            const htmlParts: string[] = [];
+
+            for (const block of blocks) {
+                let html = cache.get(block);
+                if (!html) {
+                    try {
+                        const result = transform(block, options);
+                        html = result.result.html;
+                        cache.set(block, html);
+                    } catch {
+                        html = '';
+                    }
+                }
+                htmlParts.push(html);
+            }
+
+            const currentBlocksSet = new Set(blocks);
+            for (const key of cache.keys()) {
+                if (!currentBlocksSet.has(key)) {
+                    cache.delete(key);
+                }
+            }
+
+            return htmlParts.join('');
+        } catch {
+            return '';
+        }
+    }, [content, options]);
+}

--- a/src/hooks/useRemend.ts
+++ b/src/hooks/useRemend.ts
@@ -1,0 +1,19 @@
+import {useMemo} from 'react';
+
+import remend from 'remend';
+
+export function useRemend(content: string, enabled: boolean): string {
+    return useMemo(() => {
+        if (typeof content !== 'string' || content === '') {
+            return '';
+        }
+        if (!enabled) {
+            return content;
+        }
+        try {
+            return remend(content.trim());
+        } catch {
+            return content;
+        }
+    }, [content, enabled]);
+}

--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -1,0 +1,21 @@
+import {OptionsType} from '@diplodoc/transform/lib/typings';
+
+export function areOptionsEqual(prev?: OptionsType, next?: OptionsType): boolean {
+    if (prev === next) {
+        return true;
+    }
+    if (!prev || !next) {
+        return false;
+    }
+    const prevKeys = Object.keys(prev);
+    const nextKeys = Object.keys(next);
+    if (prevKeys.length !== nextKeys.length) {
+        return false;
+    }
+    for (const key of prevKeys) {
+        if (prev[key] !== next[key]) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/utils/parse-blocks.ts
+++ b/src/utils/parse-blocks.ts
@@ -1,0 +1,83 @@
+import {Lexer} from 'marked';
+
+const footnoteReferencePattern = /\[\^[^\]\s]{1,200}\](?!:)/;
+const footnoteDefinitionPattern = /\[\^[^\]\s]{1,200}\]:/;
+const closingTagPattern = /<\/(\w+)>/;
+const openingTagPattern = /<(\w+)[\s>]/;
+
+const handleHtmlBlock = (
+    token: {type: string; raw: string; block?: boolean},
+    htmlStack: string[],
+    lastBlock: string,
+): {merged: string; shouldPopStack: boolean} | null => {
+    if (htmlStack.length === 0) {
+        return null;
+    }
+
+    const merged = lastBlock + token.raw;
+    let shouldPopStack = false;
+
+    if (token.type === 'html') {
+        const closingTagMatch = token.raw.match(closingTagPattern);
+        if (closingTagMatch) {
+            const closingTag = closingTagMatch[1];
+            if (htmlStack[htmlStack.length - 1] === closingTag) {
+                shouldPopStack = true;
+            }
+        }
+    }
+    return {merged, shouldPopStack};
+};
+
+const processOpeningHtmlTag = (
+    token: {type: string; raw: string; block?: boolean},
+    htmlStack: string[],
+): void => {
+    if (token.type !== 'html' || !token.block) {
+        return;
+    }
+
+    const openingTagMatch = token.raw.match(openingTagPattern);
+    if (openingTagMatch) {
+        const tagName = openingTagMatch[1];
+        const hasClosingTag = token.raw.includes(`</${tagName}>`);
+        if (!hasClosingTag) {
+            htmlStack.push(tagName);
+        }
+    }
+};
+
+export const parseMarkdownIntoBlocks = (markdown: string): string[] => {
+    const hasFootnoteReference = footnoteReferencePattern.test(markdown);
+    const hasFootnoteDefinition = footnoteDefinitionPattern.test(markdown);
+
+    if (hasFootnoteReference || hasFootnoteDefinition) {
+        return [markdown];
+    }
+
+    const tokens = Lexer.lex(markdown, {gfm: true});
+    const mergedBlocks: string[] = [];
+    const htmlStack: string[] = [];
+
+    for (const token of tokens) {
+        const currentBlock = token.raw;
+
+        if (mergedBlocks.length > 0) {
+            const lastBlock = mergedBlocks[mergedBlocks.length - 1];
+            const htmlResult = handleHtmlBlock(token, htmlStack, lastBlock);
+            if (htmlResult) {
+                mergedBlocks[mergedBlocks.length - 1] = htmlResult.merged;
+                if (htmlResult.shouldPopStack) {
+                    htmlStack.pop();
+                }
+                continue;
+            }
+        }
+
+        processOpeningHtmlTag(token, htmlStack);
+
+        mergedBlocks.push(currentBlock);
+    }
+
+    return mergedBlocks;
+};


### PR DESCRIPTION
## Summary

This PR introduces performance optimizations for markdown rendering by implementing block-level memoization and adds support for parsing incomplete markdown chunks during streaming.

## Changes

### Performance Improvements

- **Block-level memoization**: Markdown content is now parsed into blocks and each block is cached individually, preventing unnecessary re-rendering of unchanged blocks when content is appended (e.g., during streaming)
- **Component memoization**: `MarkdownRenderer` is now wrapped with `React.memo` with custom comparison logic to prevent unnecessary re-renders when props haven't changed

### New Features

- **Incomplete markdown parsing**: Added support for parsing incomplete markdown chunks using the `remend` library, which automatically closes unclosed markdown tags and structures
- **New prop `shouldParseIncompleteMarkdown`**: Added to `MarkdownRenderer`, `AssistantMessage`, `UserMessage`, `MessageList`, and `ChatContainer` components to enable incomplete markdown parsing

### New Utilities and Hooks

- **`useMarkdownTransform` hook**: Handles markdown transformation with block-level caching
- **`useRemend` hook**: Wraps the `remend` library for closing incomplete markdown structures
- **`parse-blocks.ts` utility**: Parses markdown content into individual blocks using the `marked` lexer, handling HTML blocks and footnotes correctly

### Dependencies

- Added `marked` (^17.0.1) - for markdown lexing and block parsing
- Added `remend` (^1.0.1) - for closing incomplete markdown structures

## Technical Details

The implementation splits markdown content into blocks using the `marked` lexer. Each block is cached separately, so when new content is appended (e.g., during streaming), only new blocks are transformed while existing blocks are retrieved from cache. This significantly improves performance for long messages and streaming scenarios.

The block parsing logic:
- Handles HTML blocks correctly by tracking opening/closing tags
- Preserves footnote references and definitions as single blocks
- Merges related tokens into logical blocks

https://github.com/user-attachments/assets/9ba884c5-5460-4cd6-9f92-47a6b65438b1

