### PR TITLE
fix(MarkdownRenderer): scope yfm theme to the renderer

### DIFF
--- a/playwright/run-docker-command.sh
+++ b/playwright/run-docker-command.sh
@@ -12,12 +12,25 @@ command_exists() {
 }
 
 run_command() {
-  $CONTAINER_TOOL run --rm --network host -it -w /work \
-    -v $(pwd):/work \
+  # Allocate a TTY only when one is attached. `docker run -t` aborts with
+  # "the input device is not a TTY" in CI and other non-interactive shells,
+  # so the flag is added conditionally to keep the script working everywhere.
+  # A plain string (not an array) is used on purpose: expanding an empty array
+  # under `set -u` errors on bash < 4.4, which macOS still ships by default.
+  local tty_flag=""
+  if [ -t 0 ]; then
+    tty_flag="-t"
+  fi
+
+  # Pass the command as separate argv entries (`"$@"`, run directly) instead of
+  # joining them with `bash -c "$*"`. The latter collapses arguments on spaces
+  # and drops quoting, so a multi-word value like `--grep "a b c"` would break.
+  $CONTAINER_TOOL run --rm --network host -i $tty_flag -w /work \
+    -v "$(pwd):/work" \
     -v "$NODE_MODULES_CACHE_DIR:/work/node_modules" \
     -e IS_DOCKER=1 \
     "$IMAGE_NAME:$IMAGE_TAG" \
-    /bin/bash -c "$*"
+    "$@"
 }
 
 if command_exists docker; then
@@ -29,7 +42,7 @@ else
   exit 1
 fi
 
-if [[ "$*" = "clear-cache" ]]; then
+if [[ "${1:-}" = "clear-cache" ]]; then
   rm -rf "$NODE_MODULES_CACHE_DIR"
   rm -rf "./playwright/.cache"
   exit 0
@@ -37,7 +50,7 @@ fi
 
 if [[ ! -d "$NODE_MODULES_CACHE_DIR" ]]; then
   mkdir -p "$NODE_MODULES_CACHE_DIR"
-  run_command 'npm ci'
+  run_command npm ci
 fi
 
-run_command "$*"
+run_command "$@"

--- a/src/components/atoms/MarkdownRenderer/MarkdownRenderer.scss
+++ b/src/components/atoms/MarkdownRenderer/MarkdownRenderer.scss
@@ -4,6 +4,8 @@
 $block: '.#{variables.$ns}markdown-renderer';
 
 #{$block} {
+    @include yfm.yfm-theme;
+
     max-width: 100%;
     overflow-x: auto;
 

--- a/src/components/atoms/MarkdownRenderer/__stories__/MarkdownRenderer.stories.tsx
+++ b/src/components/atoms/MarkdownRenderer/__stories__/MarkdownRenderer.stories.tsx
@@ -164,3 +164,25 @@ export const WithMarkdownTableInMessage: StoryObj<typeof MarkdownRenderer> = {
     ),
     decorators: defaultDecorators,
 };
+
+/**
+ * Markup a consumer renders with their own `@diplodoc/transform` usage: a bare
+ * `.yfm` container that is NOT wrapped in AIKit's namespace class. `**bold**`
+ * becomes `<strong>`, for which `@diplodoc/transform` ships `font-weight: 700`.
+ * AIKit must not leak its `.yfm` overrides onto this standalone content.
+ */
+const STANDALONE_TRANSFORM_HTML = '<p>This is <strong>bold</strong> text.</p>';
+
+export const StyleIsolation: StoryObj<typeof MarkdownRenderer> = {
+    render: () => (
+        <>
+            <MarkdownRenderer qa="aikit-yfm" content="This is **bold** text." />
+            <div
+                className="yfm"
+                data-qa="standalone-yfm"
+                dangerouslySetInnerHTML={{__html: STANDALONE_TRANSFORM_HTML}}
+            />
+        </>
+    ),
+    decorators: defaultDecorators,
+};

--- a/src/components/atoms/MarkdownRenderer/__tests__/MarkdownRenderer.visual.spec.tsx
+++ b/src/components/atoms/MarkdownRenderer/__tests__/MarkdownRenderer.visual.spec.tsx
@@ -1,4 +1,4 @@
-import {test} from '~playwright/core';
+import {expect, test} from '~playwright/core';
 
 import {MarkdownRendererStories} from './helpersPlaywright';
 
@@ -25,5 +25,22 @@ test.describe('MarkdownRenderer', {tag: '@MarkdownRenderer'}, () => {
         await mount(<MarkdownRendererStories.WithMarkdownTableInMessage />);
 
         await expectScreenshot();
+    });
+
+    test('should not leak yfm styles onto standalone @diplodoc/transform content', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<MarkdownRendererStories.StyleIsolation />);
+
+        const fontWeight = (selector: string) =>
+            page.locator(selector).evaluate((el) => getComputedStyle(el).fontWeight);
+
+        // AIKit's accent override (font-weight: 600) applies inside its own renderer.
+        await expect.poll(() => fontWeight('[data-qa="aikit-yfm"] strong')).toBe('600');
+
+        // Standalone `.yfm` content must keep `@diplodoc/transform`'s default (700)
+        // and stay untouched by AIKit's `.yfm` overrides.
+        await expect.poll(() => fontWeight('[data-qa="standalone-yfm"] strong')).toBe('700');
     });
 });

--- a/src/styles/yfm.scss
+++ b/src/styles/yfm.scss
@@ -9,9 +9,17 @@
  * Here we re-map them onto Gravity UI tokens (`--g-color-*`) so the markdown
  * content follows the active Gravity theme (`.g-root_theme_light` /
  * `.g-root_theme_dark`) automatically — no dedicated dark-theme block needed.
+ *
+ * Exposed as a mixin instead of a bare `.yfm` ruleset so the caller can scope
+ * it to AIKit's own renderer. `.yfm` is the shared root class of
+ * @diplodoc/transform, so a global `.yfm { ... }` override would leak these
+ * styles onto markdown that consumers render with their own transform setup
+ * (e.g. `<strong>`/`<b>` would inherit AIKit's accent weight instead of the
+ * transform default). Keeping the base `@import` above global is intentional —
+ * those are the standard transform styles, identical for every consumer.
  */
 
-.yfm {
+@mixin yfm-theme {
     // Base / text
     --yfm-color-base: var(--g-color-base-background);
     --yfm-color-text: var(--g-color-text-primary);


### PR DESCRIPTION
## Problem

YFM theming lived in a global `.yfm { ... }` ruleset (`src/styles/yfm.scss`).
`.yfm` is the **shared root class of `@diplodoc/transform`**, so these AIKit
overrides were not scoped to AIKit at all — they applied to *any* `.yfm`
element on the page.

For consumers who use `@diplodoc/transform` directly **and** pull in AIKit's
chat, AIKit's CSS (loaded after the transform base CSS) won the cascade on
their own markdown. The clearest symptom is `<strong>` / `<b>`: AIKit remaps
them to its accent weight (`--g-text-accent-font-weight: 600`), overriding the
transform default of `700` on content AIKit never rendered. The same leak
applied to the whole `--yfm-color-*` remap, links, code, notes, etc.

## What I hit while running the tests (and why the second commit exists)

Per the testing guidelines all Playwright tests must run through Docker
(`npm run playwright:docker`). Running them surfaced two issues in
`playwright/run-docker-command.sh`, fixed in the `chore(playwright): ...`
commit so the runner keeps working out of the box for everyone:

1. **`docker run -it` requires a TTY.** In CI / non-interactive shells it
   aborts immediately with `the input device is not a TTY`. We now allocate
   `-t` only when a TTY is attached (`[ -t 0 ]`) and always keep `-i`.
   A plain string (not a bash array) holds the flag on purpose: expanding an
   empty array under `set -u` errors on bash < 4.4, and macOS still ships
   bash 3.2 by default — so the array variant would break local runs.

2. **`--grep "a b c"` matched no tests.** The runner executed the command via
   `bash -c "$*"`, which joins all arguments into one space-separated string
   and drops quoting, so a multi-word grep was split into separate words
   ("No tests found"). We now pass the command as `"$@"` and run it directly,
   preserving argv exactly.