### PR TITLE
feat(PromptInput): expose textarea control ref

### DIFF
--- a/src/components/organisms/PromptInput/PromptInputFull.tsx
+++ b/src/components/organisms/PromptInput/PromptInputFull.tsx
@@ -48,7 +48,7 @@ export function PromptInputFull(props: PromptInputFullProps) {
         minRows = 1,
         maxRows = 15,
         autoFocus = false,
-        controlRef,
+        inputRef,
         qa: bodyQa,
     } = bodyProps;
 
@@ -91,7 +91,7 @@ export function PromptInputFull(props: PromptInputFullProps) {
                 minRows={minRows}
                 maxRows={maxRows}
                 autoFocus={autoFocus}
-                ref={controlRef}
+                ref={inputRef}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
                 inputClassName={b('textarea')}

--- a/src/components/organisms/PromptInput/PromptInputFull.tsx
+++ b/src/components/organisms/PromptInput/PromptInputFull.tsx
@@ -48,6 +48,7 @@ export function PromptInputFull(props: PromptInputFullProps) {
         minRows = 1,
         maxRows = 15,
         autoFocus = false,
+        controlRef,
         qa: bodyQa,
     } = bodyProps;
 
@@ -90,6 +91,7 @@ export function PromptInputFull(props: PromptInputFullProps) {
                 minRows={minRows}
                 maxRows={maxRows}
                 autoFocus={autoFocus}
+                ref={controlRef}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
                 inputClassName={b('textarea')}

--- a/src/components/organisms/PromptInput/PromptInputSimple.tsx
+++ b/src/components/organisms/PromptInput/PromptInputSimple.tsx
@@ -37,7 +37,7 @@ export function PromptInputSimple(props: PromptInputSimpleProps) {
         minRows = 1,
         maxRows = 15,
         autoFocus = false,
-        controlRef,
+        inputRef,
         qa: bodyQa,
     } = bodyProps;
 
@@ -66,7 +66,7 @@ export function PromptInputSimple(props: PromptInputSimpleProps) {
                     minRows={minRows}
                     maxRows={maxRows}
                     autoFocus={autoFocus}
-                    ref={controlRef}
+                    ref={inputRef}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
                     qa={bodyQa}

--- a/src/components/organisms/PromptInput/PromptInputSimple.tsx
+++ b/src/components/organisms/PromptInput/PromptInputSimple.tsx
@@ -37,6 +37,7 @@ export function PromptInputSimple(props: PromptInputSimpleProps) {
         minRows = 1,
         maxRows = 15,
         autoFocus = false,
+        controlRef,
         qa: bodyQa,
     } = bodyProps;
 
@@ -65,6 +66,7 @@ export function PromptInputSimple(props: PromptInputSimpleProps) {
                     minRows={minRows}
                     maxRows={maxRows}
                     autoFocus={autoFocus}
+                    ref={controlRef}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
                     qa={bodyQa}

--- a/src/components/organisms/PromptInput/README.md
+++ b/src/components/organisms/PromptInput/README.md
@@ -147,12 +147,16 @@ import {PromptInput} from '@gravity-ui/aikit';
 
 ### PromptInputBodyConfig
 
-| Prop          | Type      | Required | Default                                 | Description                     |
-| ------------- | --------- | -------- | --------------------------------------- | ------------------------------- |
-| `placeholder` | `string`  | -        | `'Plan, code, build and test anything'` | Placeholder text for textarea   |
-| `minRows`     | `number`  | -        | `1`                                     | Minimum number of textarea rows |
-| `maxRows`     | `number`  | -        | `15`                                    | Maximum number of textarea rows |
-| `autoFocus`   | `boolean` | -        | `false`                                 | Auto focus textarea on mount    |
+| Prop                    | Type                       | Required | Default                                 | Description                                 |
+| ----------------------- | -------------------------- | -------- | --------------------------------------- | ------------------------------------------- |
+| `qa`                    | `string`                   | -        | -                                       | QA/test identifier for body wrapper         |
+| `inputRef`              | `Ref<HTMLTextAreaElement>` | -        | -                                       | Ref to the textarea input                   |
+| `placeholder`           | `string`                   | -        | `'Plan, code, build and test anything'` | Placeholder text for textarea               |
+| `minRows`               | `number`                   | -        | `1`                                     | Minimum number of textarea rows             |
+| `maxRows`               | `number`                   | -        | `15`                                    | Maximum number of textarea rows             |
+| `autoFocus`             | `boolean`                  | -        | `false`                                 | Auto focus textarea on mount                |
+| `autoFocusOnNewChat`    | `boolean`                  | -        | `false`                                 | Auto focus textarea when a new chat is open |
+| `autoFocusOnChatSelect` | `boolean`                  | -        | `false`                                 | Auto focus textarea when a chat is selected |
 
 ### PromptInputFooterConfig
 

--- a/src/components/organisms/PromptInput/types.ts
+++ b/src/components/organisms/PromptInput/types.ts
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import {ReactNode, type Ref} from 'react';
 
 import type {SuggestionsItem} from '../../../types/common';
 import {PromptInputHeaderProps} from '../../molecules/PromptInputHeader';
@@ -36,6 +36,8 @@ export type PromptInputHeaderConfig = {
 export type PromptInputBodyConfig = {
     /** QA/test identifier for body wrapper */
     qa?: string;
+    /** Ref to the textarea control */
+    controlRef?: Ref<HTMLTextAreaElement>;
     /** Placeholder text for textarea */
     placeholder?: string;
     /** Minimum number of textarea rows */

--- a/src/components/organisms/PromptInput/types.ts
+++ b/src/components/organisms/PromptInput/types.ts
@@ -36,8 +36,8 @@ export type PromptInputHeaderConfig = {
 export type PromptInputBodyConfig = {
     /** QA/test identifier for body wrapper */
     qa?: string;
-    /** Ref to the textarea control */
-    controlRef?: Ref<HTMLTextAreaElement>;
+    /** Ref to the textarea input */
+    inputRef?: Ref<HTMLTextAreaElement>;
     /** Placeholder text for textarea */
     placeholder?: string;
     /** Minimum number of textarea rows */


### PR DESCRIPTION
## Summary

Expose a textarea control ref through `PromptInputBodyConfig` and pass it to the existing `PromptInputBody` ref in both full and simple prompt input views.

## Motivation

Consumers that render `ChatContainer` inside an external focus-managed shell, for example a drawer or modal, may need to coordinate focus after the shell transition completes.

Today `PromptInputBody` already forwards a ref to the underlying Gravity UI `TextArea`, but `PromptInput` / `ChatContainer` do not expose a way to provide that ref from the outside. Consumers can only rely on `autoFocus`, `autoFocusOnNewChat`, or `autoFocusOnChatSelect`, which do not cover an external "chat opened in drawer" lifecycle.

This makes consumers fall back to DOM queries against QA selectors when they need to focus the prompt after opening an external panel. Exposing `controlRef` keeps the API typed and avoids brittle selectors.

## Changes

- Add `controlRef?: Ref<HTMLTextAreaElement>` to `PromptInputBodyConfig`.
- Pass `bodyProps.controlRef` to `PromptInputBody` in `PromptInputFull`.
- Pass `bodyProps.controlRef` to `PromptInputBody` in `PromptInputSimple`.

## Verification

- `npm run typecheck`
- `npx eslint src/components/organisms/PromptInput/types.ts src/components/organisms/PromptInput/PromptInputFull.tsx src/components/organisms/PromptInput/PromptInputSimple.tsx`
