### PR TITLE
fix(actions): show actions when popup open

### DIFF
--- a/src/components/organisms/MessageList/MessageList.tsx
+++ b/src/components/organisms/MessageList/MessageList.tsx
@@ -22,7 +22,7 @@ import {type RatingBlockProps} from '../../molecules/RatingBlock/RatingBlock';
 import {MessageItem} from './MessageItem';
 import {VirtualizedMessageList} from './MessageList.virtualized';
 import {MessageListFooter} from './MessageListFooter';
-import {usePopup} from './usePopup';
+import {isActionPopupOpenForMessage, usePopup} from './usePopup';
 
 import './MessageList.scss';
 
@@ -154,10 +154,13 @@ function PlainMessageList<TContent extends TMessageContent = never>({
                         key={message.id || `message-${index}`}
                         message={message}
                         suppressActions={index === messages.length - 1 && isNotCompleted}
+                        showActionsOnHover={
+                            showActionsOnHover &&
+                            !isActionPopupOpenForMessage(popupState, message.id)
+                        }
                         messageRendererRegistry={messageRendererRegistry}
                         transformOptions={transformOptions}
                         shouldParseIncompleteMarkdown={shouldParseIncompleteMarkdown}
-                        showActionsOnHover={showActionsOnHover}
                         showTimestamp={showTimestamp}
                         showAvatar={showAvatar}
                         userActions={userActions}

--- a/src/components/organisms/MessageList/MessageList.virtualized.tsx
+++ b/src/components/organisms/MessageList/MessageList.virtualized.tsx
@@ -11,7 +11,7 @@ import {Loader} from '../../atoms/Loader';
 import {MessageItem, type MessageItemConfig} from './MessageItem';
 import {type MessageListProps, MessageListQa} from './MessageList';
 import {MessageListFooter} from './MessageListFooter';
-import {usePopup} from './usePopup';
+import {type PopupState, isActionPopupOpenForMessage, usePopup} from './usePopup';
 
 const b = block('message-list');
 
@@ -28,6 +28,7 @@ type MessageRowProps = {
     headerOffset: number;
     hasPreviousMessages: boolean;
     onLoadPreviousMessages?: () => void;
+    popupState: PopupState;
     config: MessageItemConfig<TMessageContent>;
 };
 
@@ -40,6 +41,7 @@ function MessageRow({
     headerOffset,
     hasPreviousMessages,
     onLoadPreviousMessages,
+    popupState,
     config,
 }: RowComponentProps<MessageRowProps>) {
     // Header row: the "load previous messages" intersection trigger.
@@ -73,6 +75,10 @@ function MessageRow({
                     message={message}
                     suppressActions={isLast && isNotCompleted}
                     {...config}
+                    showActionsOnHover={
+                        Boolean(config.showActionsOnHover) &&
+                        !isActionPopupOpenForMessage(popupState, message.id)
+                    }
                 />
             </div>
         </div>
@@ -151,6 +157,7 @@ export function VirtualizedMessageList<TContent extends TMessageContent = never>
             headerOffset,
             hasPreviousMessages,
             onLoadPreviousMessages,
+            popupState,
             config: config as unknown as MessageItemConfig<TMessageContent>,
         }),
         [
@@ -159,6 +166,7 @@ export function VirtualizedMessageList<TContent extends TMessageContent = never>
             headerOffset,
             hasPreviousMessages,
             onLoadPreviousMessages,
+            popupState,
             config,
         ],
     );

--- a/src/components/organisms/MessageList/README.md
+++ b/src/components/organisms/MessageList/README.md
@@ -275,6 +275,8 @@ The `getContent` function receives a context object with the following methods:
 - `setSubtitle(subtitle: string | undefined)` — Update popup subtitle dynamically (pass `undefined` to hide)
 - `closePopup()` — Programmatically close the popup
 
+When `showActionsOnHover` is enabled, `MessageList` temporarily disables hover-hiding for the message whose action popup is open, so users can interact with the popup without losing the anchor buttons.
+
 **ActionPopup Configuration:**
 
 ```typescript

--- a/src/components/organisms/MessageList/__stories__/parts/popups.tsx
+++ b/src/components/organisms/MessageList/__stories__/parts/popups.tsx
@@ -119,7 +119,11 @@ Do you confirm the creation?`,
         return (
             <ShowcaseItem title="With Feedback Popup - Click dislike to see feedback form">
                 <ContentWrapper width="600px" height="500px" display="flex">
-                    <MessageList messages={messages} assistantActions={assistantActions} />
+                    <MessageList
+                        messages={messages}
+                        assistantActions={assistantActions}
+                        showActionsOnHover
+                    />
                 </ContentWrapper>
             </ShowcaseItem>
         );

--- a/src/components/organisms/MessageList/__tests__/MessageList.visual.spec.tsx
+++ b/src/components/organisms/MessageList/__tests__/MessageList.visual.spec.tsx
@@ -1,3 +1,5 @@
+import type {Page} from '@playwright/test';
+
 import {expect, test} from '~playwright/core';
 
 import type {TAssistantMessage, TUserMessage} from '../../../../types/messages';
@@ -7,9 +9,7 @@ import {MessageList} from '../MessageList';
 import {MessageListStories} from './helpersPlaywright';
 
 /** Reveal action buttons hidden by showActionsOnHover before interacting with them. */
-async function hoverAssistantMessage(page: {
-    locator: (selector: string) => {hover: () => Promise<void>};
-}) {
+async function hoverAssistantMessage(page: Page) {
     await page.locator('.g-aikit-base-message_variant_assistant').hover();
 }
 

--- a/src/components/organisms/MessageList/__tests__/MessageList.visual.spec.tsx
+++ b/src/components/organisms/MessageList/__tests__/MessageList.visual.spec.tsx
@@ -6,6 +6,13 @@ import {MessageList} from '../MessageList';
 
 import {MessageListStories} from './helpersPlaywright';
 
+/** Reveal action buttons hidden by showActionsOnHover before interacting with them. */
+async function hoverAssistantMessage(page: {
+    locator: (selector: string) => {hover: () => Promise<void>};
+}) {
+    await page.locator('.g-aikit-base-message_variant_assistant').hover();
+}
+
 test.describe('MessageList', {tag: '@MessageList'}, () => {
     test('should render default state', async ({mount, expectScreenshot}) => {
         await mount(<MessageListStories.Playground />);
@@ -316,6 +323,7 @@ test.describe('MessageList', {tag: '@MessageList'}, () => {
         test('should open feedback popup on dislike click', async ({mount, page}) => {
             await mount(<MessageListStories.WithFeedbackPopup />);
 
+            await hoverAssistantMessage(page);
             await page.locator('.g-aikit-base-message__actions').getByRole('button').nth(1).click();
 
             await expect(page.getByText('What went wrong?')).toBeVisible();
@@ -325,6 +333,7 @@ test.describe('MessageList', {tag: '@MessageList'}, () => {
         test('should render feedback popup screenshot', async ({mount, page, expectScreenshot}) => {
             await mount(<MessageListStories.WithFeedbackPopup />);
 
+            await hoverAssistantMessage(page);
             await page.locator('.g-aikit-base-message__actions').getByRole('button').nth(1).click();
 
             await expect(page.getByText('What went wrong?')).toBeVisible();
@@ -338,6 +347,7 @@ test.describe('MessageList', {tag: '@MessageList'}, () => {
         }) => {
             await mount(<MessageListStories.WithFeedbackPopup />);
 
+            await hoverAssistantMessage(page);
             await page.locator('.g-aikit-base-message__actions').getByRole('button').nth(1).click();
 
             await expect(page.getByText('What went wrong?')).toBeVisible();
@@ -349,9 +359,29 @@ test.describe('MessageList', {tag: '@MessageList'}, () => {
             await expect(page.getByText('What went wrong?')).not.toBeVisible();
         });
 
+        test('should keep message actions visible while feedback popup is open', async ({
+            mount,
+            page,
+        }) => {
+            await mount(<MessageListStories.WithFeedbackPopup />);
+
+            const actions = page.locator('.g-aikit-base-message__actions');
+            await hoverAssistantMessage(page);
+            await actions.getByRole('button').nth(1).click();
+
+            await expect(page.getByText('What went wrong?')).toBeVisible();
+
+            // Move cursor away from the message (popup stays open)
+            await page.mouse.move(0, 0);
+
+            await expect(actions).toBeVisible();
+            await expect(actions.getByRole('button')).toHaveCount(3);
+        });
+
         test('should close popup when clicking outside', async ({mount, page}) => {
             await mount(<MessageListStories.WithFeedbackPopup />);
 
+            await hoverAssistantMessage(page);
             await page.locator('.g-aikit-base-message__actions').getByRole('button').nth(1).click();
 
             await expect(page.getByText('What went wrong?')).toBeVisible();

--- a/src/components/organisms/MessageList/__tests__/isActionPopupOpenForMessage.unit.test.ts
+++ b/src/components/organisms/MessageList/__tests__/isActionPopupOpenForMessage.unit.test.ts
@@ -1,0 +1,30 @@
+import {type PopupState, isActionPopupOpenForMessage} from '../usePopup';
+
+const closedPopup: PopupState = {
+    open: false,
+    messageId: null,
+    actionType: null,
+    anchorElement: null,
+    content: null,
+    title: undefined,
+    subtitle: undefined,
+    actionConfig: null,
+};
+
+describe('isActionPopupOpenForMessage', () => {
+    it('returns false when popup is closed', () => {
+        expect(isActionPopupOpenForMessage(closedPopup, 'msg-1')).toBe(false);
+    });
+
+    it('returns true when popup is open for the message', () => {
+        expect(
+            isActionPopupOpenForMessage({...closedPopup, open: true, messageId: 'msg-1'}, 'msg-1'),
+        ).toBe(true);
+    });
+
+    it('returns false when popup is open for a different message', () => {
+        expect(
+            isActionPopupOpenForMessage({...closedPopup, open: true, messageId: 'msg-2'}, 'msg-1'),
+        ).toBe(false);
+    });
+});

--- a/src/components/organisms/MessageList/usePopup.ts
+++ b/src/components/organisms/MessageList/usePopup.ts
@@ -125,3 +125,11 @@ export function usePopup<TContent extends TMessageContent, TMessageMetadata>() {
         showActionPopup,
     };
 }
+
+/** Whether an action popup is open and anchored to the given message. */
+export function isActionPopupOpenForMessage(
+    popupState: PopupState,
+    messageId: string | undefined,
+): boolean {
+    return Boolean(popupState.open && messageId && popupState.messageId === messageId);
+}

--- a/src/components/pages/ChatContainer/README.md
+++ b/src/components/pages/ChatContainer/README.md
@@ -617,6 +617,8 @@ const messages: TMessage[] = [
 <ChatContainer messages={messages} onSendMessage={handleSendMessage} showActionsOnHover={true} />;
 ```
 
+When `showActionsOnHover` is enabled and an action opens a popup (for example, a dislike feedback form), action buttons on that message stay visible while the popup is open so users can fill the form without losing the anchor buttons. This is handled by the library; no extra configuration is required.
+
 ### 2. Default Actions (Recommended)
 
 Use `messageListConfig` prop with `userActions` and `assistantActions` to provide default actions for all messages of that role. This is cleaner and more maintainable than adding actions to each message individually:


### PR DESCRIPTION
**Summary**
Fixes message action buttons disappearing when a user opens an action popup (e.g. dislike feedback form) with showActionsOnHover enabled.

**Problem**
In AI assistant chats, message actions (like, dislike, copy) are shown on hover. When the user clicks dislike, a feedback popup opens in a portal outside the message DOM. Moving the cursor into the popup removes hover from the message, so action buttons are hidden via visibility: hidden — including the dislike anchor button.

**Solution**
MessageList detects when an action popup is open for a specific message (usePopup state) and temporarily passes showActionsOnHover={false} for that message only. Actions stay visible while the popup is open; other messages are unaffected.

Implemented in both plain and virtualized list variants. Added isActionPopupOpenForMessage() helper, unit/visual tests, and README updates. WithFeedbackPopup story now uses showActionsOnHover to match the AI assistant scenario.