### PR TITLE
fix(markdown): fix import for esm

### DIFF
--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -1,4 +1,4 @@
-import defaultTransformPlugins from '@diplodoc/transform/lib/plugins';
+import defaultTransformPlugins from '@diplodoc/transform/lib/plugins.js';
 import {OptionsType} from '@diplodoc/transform/lib/typings';
 
 import {markdownTableWrapPlugin} from './markdownTableWrapPlugin';


### PR DESCRIPTION
Fix ESM build break in strict bundlers (Rspack/webpack): use @diplodoc/transform/lib/plugins.js instead of extensionless @diplodoc/transform/lib/plugins in mergeMarkdownTransformOptions.