### PR TITLE
feat(suggestions): pass suggestion context on click

### DIFF
--- a/src/components/molecules/Suggestions/README.md
+++ b/src/components/molecules/Suggestions/README.md
@@ -5,9 +5,9 @@ A Suggestions component displays a group of clickable suggestion buttons arrange
 ## Features
 
 - **Flexible layout**: Display suggestions in grid (horizontal) or list (vertical) layout
-- **Item support**: Each suggestion can have an optional ID and required title
+- **Item support**: Each suggestion can have an optional ID, optional `data` payload, and required title
 - **Optional title**: Display a section title above suggestions
-- **Click handling**: Callback function receives both content and optional ID
+- **Click handling**: Callback receives `title`, optional `id`, and optional `data`
 - **Text alignment**: Control text alignment inside buttons (left, center, right)
 - **Icon support**: Add ChevronLeft or ChevronRight icons to suggestion buttons
 - **Tooltips**: Automatic tooltips displaying the suggestion title on hover (disabled when `wrapText` is enabled)
@@ -115,26 +115,27 @@ import {Suggestions} from '@/components/molecules/Suggestions';
 
 ## Props
 
-| Prop        | Type                                                      | Required | Default  | Description                                                                                      |
-| ----------- | --------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `items`     | `SuggestionsItem[]`                                       | Yes      | -        | Array of suggestion items to display                                                             |
-| `onClick`   | `(content: string, id?: string) => void \| Promise<void>` | Yes      | -        | Callback function called when a suggestion is clicked                                            |
-| `title`     | `string`                                                  | No       | -        | Title to display above suggestions                                                               |
-| `layout`    | `'grid' \| 'list'`                                        | No       | `'list'` | Layout orientation: 'grid' for horizontal, 'list' for vertical                                   |
-| `textAlign` | `'left' \| 'center' \| 'right'`                           | No       | `'left'` | Text alignment inside buttons                                                                    |
-| `wrapText`  | `boolean`                                                 | No       | `false`  | Wrap text inside buttons instead of truncating with ellipsis; also disables the per-item tooltip |
-| `className` | `string`                                                  | No       | -        | Additional CSS class                                                                             |
-| `qa`        | `string`                                                  | No       | -        | QA/test identifier                                                                               |
+| Prop        | Type                            | Required | Default  | Description                                                                                      |
+| ----------- | ------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `items`     | `SuggestionsItem[]`             | Yes      | -        | Array of suggestion items to display                                                             |
+| `onClick`   | `SuggestionClickHandler`        | Yes      | -        | Callback function called when a suggestion is clicked                                            |
+| `title`     | `string`                        | No       | -        | Title to display above suggestions                                                               |
+| `layout`    | `'grid' \| 'list'`              | No       | `'list'` | Layout orientation: 'grid' for horizontal, 'list' for vertical                                   |
+| `textAlign` | `'left' \| 'center' \| 'right'` | No       | `'left'` | Text alignment inside buttons                                                                    |
+| `wrapText`  | `boolean`                       | No       | `false`  | Wrap text inside buttons instead of truncating with ellipsis; also disables the per-item tooltip |
+| `className` | `string`                        | No       | -        | Additional CSS class                                                                             |
+| `qa`        | `string`                        | No       | -        | QA/test identifier                                                                               |
 
 ### SuggestionsItem
 
-| Prop      | Type                                                      | Required | Default      | Description                                                               |
-| --------- | --------------------------------------------------------- | -------- | ------------ | ------------------------------------------------------------------------- |
-| `id`      | `string`                                                  | No       | -            | Optional unique identifier for the item                                   |
-| `title`   | `string`                                                  | Yes      | -            | Title text to display on the button                                       |
-| `view`    | `ButtonButtonProps['view']`                               | No       | `'outlined'` | Button view style                                                         |
-| `icon`    | `'left' \| 'right'`                                       | No       | -            | Icon position: 'left' for ChevronLeft, 'right' for ChevronRight           |
-| `onClick` | `(content: string, id?: string) => void \| Promise<void>` | No       | -            | Additional callback invoked before the component-level `onClick` callback |
+| Prop      | Type                        | Required | Default      | Description                                                               |
+| --------- | --------------------------- | -------- | ------------ | ------------------------------------------------------------------------- |
+| `id`      | `string`                    | No       | -            | Optional unique identifier for the item                                   |
+| `title`   | `string`                    | Yes      | -            | Title text to display on the button                                       |
+| `data`    | `Record<string, unknown>`   | No       | -            | Optional custom payload passed through to click handlers                  |
+| `view`    | `ButtonButtonProps['view']` | No       | `'outlined'` | Button view style                                                         |
+| `icon`    | `'left' \| 'right'`         | No       | -            | Icon position: 'left' for ChevronLeft, 'right' for ChevronRight           |
+| `onClick` | `SuggestionClickHandler`    | No       | -            | Additional callback invoked before the component-level `onClick` callback |
 
 ## Styling
 
@@ -155,3 +156,15 @@ The component uses a flex container with configurable orientation based on the `
 ### Button styling
 
 Buttons have hover effects with shadow and border radius transitions.
+
+### SuggestionClickHandler
+
+```tsx
+type SuggestionClickHandler = (
+  content: string,
+  id?: string,
+  data?: Record<string, unknown>,
+) => void | Promise<void>;
+```
+
+The handler receives the suggestion `title` as `content`, the optional `id`, and the optional `data` payload from `SuggestionsItem`.

--- a/src/components/molecules/Suggestions/Suggestions.tsx
+++ b/src/components/molecules/Suggestions/Suggestions.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {ChevronLeft, ChevronRight} from '@gravity-ui/icons';
 import {Icon, Text} from '@gravity-ui/uikit';
 
-import type {SuggestionsItem} from '../../../types/common';
+import type {SuggestionClickHandler, SuggestionsItem} from '../../../types/common';
 import {block} from '../../../utils/cn';
 import {ActionButton} from '../../atoms/ActionButton';
 
@@ -18,7 +18,7 @@ export type SuggestionsProps = {
     /** Array of suggestion items to display */
     items: SuggestionsItem[];
     /** Callback function called when a suggestion is clicked */
-    onClick: (content: string, id?: string) => void | Promise<void>;
+    onClick: SuggestionClickHandler;
     /** Title to display above suggestions - can be string or custom React element */
     title?: React.ReactNode;
     /** Layout orientation: 'grid' for horizontal, 'list' for vertical */
@@ -53,8 +53,8 @@ export function Suggestions(props: SuggestionsProps) {
     } = props;
 
     const handleClick = async (item: SuggestionsItem) => {
-        await item.onClick?.(item.title, item.id);
-        await onClick(item.title, item.id);
+        await item.onClick?.(item.title, item.id, item.data);
+        await onClick(item.title, item.id, item.data);
     };
 
     const renderButton = (item: SuggestionsItem, index: number) => {

--- a/src/components/organisms/PromptInput/PromptInput.tsx
+++ b/src/components/organisms/PromptInput/PromptInput.tsx
@@ -87,11 +87,11 @@ export function PromptInput(props: PromptInputProps) {
     });
 
     // Handle suggestion click with custom handler or default to input change
-    const handleSuggestionClick = (suggestion: string) => {
+    const handleSuggestionClick = (content: string, id?: string) => {
         if (suggestionsProps?.onSuggestionClick) {
-            suggestionsProps.onSuggestionClick(suggestion);
+            suggestionsProps.onSuggestionClick(content, id);
         } else {
-            hookState.handleChange(suggestion);
+            hookState.handleChange(content);
         }
     };
 

--- a/src/components/organisms/PromptInput/PromptInput.tsx
+++ b/src/components/organisms/PromptInput/PromptInput.tsx
@@ -87,9 +87,13 @@ export function PromptInput(props: PromptInputProps) {
     });
 
     // Handle suggestion click with custom handler or default to input change
-    const handleSuggestionClick = (content: string, id?: string) => {
+    const handleSuggestionClick = (
+        content: string,
+        id?: string,
+        data?: Record<string, unknown>,
+    ) => {
         if (suggestionsProps?.onSuggestionClick) {
-            suggestionsProps.onSuggestionClick(content, id);
+            suggestionsProps.onSuggestionClick(content, id, data);
         } else {
             hookState.handleChange(content);
         }

--- a/src/components/organisms/PromptInput/README.md
+++ b/src/components/organisms/PromptInput/README.md
@@ -175,14 +175,14 @@ import {PromptInput} from '@gravity-ui/aikit';
 
 ### PromptInputSuggestionsConfig
 
-| Prop                   | Type                                     | Required | Default    | Description                       |
-| ---------------------- | ---------------------------------------- | -------- | ---------- | --------------------------------- |
-| `suggestions`          | `SuggestionsItem[]`                      | -        | -          | Submit suggestions array          |
-| `showSuggestions`      | `boolean`                                | -        | `false`    | Show submit suggestions           |
-| `suggestTitle`         | `string`                                 | -        | -          | Title for the suggestions section |
-| `suggestionsLayout`    | `'grid' \| 'list'`                       | -        | -          | Layout orientation                |
-| `suggestionsTextAlign` | `'left' \| 'center' \| 'right'`          | -        | `'center'` | Text alignment                    |
-| `onSuggestionClick`    | `(content: string, id?: string) => void` | -        | -          | Callback when suggestion clicked  |
+| Prop                   | Type                            | Required | Default    | Description                       |
+| ---------------------- | ------------------------------- | -------- | ---------- | --------------------------------- |
+| `suggestions`          | `SuggestionsItem[]`             | -        | -          | Submit suggestions array          |
+| `showSuggestions`      | `boolean`                       | -        | `false`    | Show submit suggestions           |
+| `suggestTitle`         | `string`                        | -        | -          | Title for the suggestions section |
+| `suggestionsLayout`    | `'grid' \| 'list'`              | -        | -          | Layout orientation                |
+| `suggestionsTextAlign` | `'left' \| 'center' \| 'right'` | -        | `'center'` | Text alignment                    |
+| `onSuggestionClick`    | `SuggestionClickHandler`        | -        | -          | Callback when suggestion clicked  |
 
 Suggestions always render with text wrapping enabled: full suggestion text wraps to multiple lines instead of being truncated with an ellipsis. This is not configurable, since prompt suggestions are full-length phrases that must stay readable.
 

--- a/src/components/organisms/PromptInput/__stories__/PromptInput.stories.tsx
+++ b/src/components/organisms/PromptInput/__stories__/PromptInput.stories.tsx
@@ -125,11 +125,19 @@ export const WithSuggestionIdCallback: Story = {
                     suggestionsProps={{
                         showSuggestions: true,
                         suggestions: [
-                            {id: 'approve', title: 'Yes', view: 'action'},
+                            {
+                                id: 'approve',
+                                title: 'Yes',
+                                view: 'action',
+                                data: {reason: 'confirmed'},
+                            },
                             {id: 'reject', title: 'No'},
                         ],
-                        onSuggestionClick: (content, id) => {
-                            setClickedSuggestion(`${content}:${id}`);
+                        onSuggestionClick: (content, id, data) => {
+                            const reason = data?.reason;
+                            setClickedSuggestion(
+                                `${content}:${id}:${typeof reason === 'string' ? reason : ''}`,
+                            );
                         },
                     }}
                 />

--- a/src/components/organisms/PromptInput/__stories__/PromptInput.stories.tsx
+++ b/src/components/organisms/PromptInput/__stories__/PromptInput.stories.tsx
@@ -109,6 +109,36 @@ export const WithSuggestions: Story = {
     decorators: defaultDecorators,
 };
 
+export const WithSuggestionIdCallback: Story = {
+    render: () => {
+        const [clickedSuggestion, setClickedSuggestion] = useState('');
+
+        return (
+            <>
+                <div data-qa="suggestion-click">{clickedSuggestion}</div>
+                <PromptInput
+                    view="simple"
+                    onSend={handleSend}
+                    bodyProps={{
+                        placeholder: 'Plan, code, build and test anything',
+                    }}
+                    suggestionsProps={{
+                        showSuggestions: true,
+                        suggestions: [
+                            {id: 'approve', title: 'Yes', view: 'action'},
+                            {id: 'reject', title: 'No'},
+                        ],
+                        onSuggestionClick: (content, id) => {
+                            setClickedSuggestion(`${content}:${id}`);
+                        },
+                    }}
+                />
+            </>
+        );
+    },
+    decorators: defaultDecorators,
+};
+
 export const WithSuggestionsAndTitle: Story = {
     args: {
         view: 'simple',

--- a/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
+++ b/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
@@ -26,7 +26,9 @@ test.describe('PromptInput', {tag: '@PromptInput'}, () => {
 
         await page.getByRole('button', {name: 'Yes'}).click();
 
-        await expect(page.locator('[data-qa="suggestion-click"]')).toHaveText('Yes:approve');
+        await expect(page.locator('[data-qa="suggestion-click"]')).toHaveText(
+            'Yes:approve:confirmed',
+        );
     });
 
     test('should render with suggestions and title', async ({mount, expectScreenshot}) => {

--- a/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
+++ b/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
@@ -1,4 +1,4 @@
-import {test} from '~playwright/core';
+import {expect, test} from '~playwright/core';
 
 import {PromptInputStories} from './helpersPlaywright';
 
@@ -19,6 +19,14 @@ test.describe('PromptInput', {tag: '@PromptInput'}, () => {
         await mount(<PromptInputStories.WithSuggestions />);
 
         await expectScreenshot();
+    });
+
+    test('should forward suggestion id to onSuggestionClick', async ({mount, page}) => {
+        await mount(<PromptInputStories.WithSuggestionIdCallback />);
+
+        await page.getByRole('button', {name: 'Yes'}).click();
+
+        await expect(page.locator('[data-qa="suggestion-click"]')).toHaveText('Yes:approve');
     });
 
     test('should render with suggestions and title', async ({mount, expectScreenshot}) => {

--- a/src/components/organisms/PromptInput/types.ts
+++ b/src/components/organisms/PromptInput/types.ts
@@ -1,6 +1,6 @@
 import {ReactNode, type Ref} from 'react';
 
-import type {SuggestionsItem} from '../../../types/common';
+import type {SuggestionClickHandler, SuggestionsItem} from '../../../types/common';
 import {PromptInputHeaderProps} from '../../molecules/PromptInputHeader';
 import type {SuggestionsProps} from '../../molecules/Suggestions';
 
@@ -108,5 +108,5 @@ export type PromptInputSuggestionsConfig = {
     /** Text alignment inside suggestion buttons */
     suggestionsTextAlign?: SuggestionsProps['textAlign'];
     /** Callback when suggestion is clicked */
-    onSuggestionClick?: (content: string, id?: string) => void;
+    onSuggestionClick?: SuggestionClickHandler;
 };

--- a/src/components/pages/ChatContainer/ChatContainer.tsx
+++ b/src/components/pages/ChatContainer/ChatContainer.tsx
@@ -298,8 +298,11 @@ export function ChatContainer(props: ChatContainerProps) {
                 welcomeConfig?.showMoreText ??
                 emptyContainerProps.showMoreText ??
                 i18n('empty-state-show-more'),
-            onSuggestionClick: async (clickedTitle: string) => {
-                await onSendMessage({content: clickedTitle});
+            onSuggestionClick: async (content: string, suggestionId?: string) => {
+                await onSendMessage({
+                    content,
+                    ...(suggestionId && {metadata: {suggestion_id: suggestionId}}),
+                });
             },
         };
     }, [

--- a/src/components/pages/ChatContainer/ChatContainer.tsx
+++ b/src/components/pages/ChatContainer/ChatContainer.tsx
@@ -1,5 +1,6 @@
 import {type ReactNode, useMemo} from 'react';
 
+import type {TSuggestionContext} from '../../../types/messages';
 import {block} from '../../../utils/cn';
 import {Disclaimer} from '../../atoms/Disclaimer';
 import {Header, HeaderAction, type HeaderProps} from '../../organisms/Header';
@@ -21,6 +22,20 @@ import './ChatContainer.scss';
 const b = block('chat-container');
 
 type NormalizedChatContainerQa = ReturnType<typeof normalizeChatContainerQa>;
+
+function toSuggestionContext(
+    id?: string,
+    data?: Record<string, unknown>,
+): TSuggestionContext | undefined {
+    if (!id && !data) {
+        return undefined;
+    }
+
+    return {
+        ...(id && {id}),
+        ...(data && {data}),
+    };
+}
 
 function mergePromptInputSuggestionsProps(
     fromProps: PromptInputProps['suggestionsProps'] | undefined,
@@ -298,10 +313,16 @@ export function ChatContainer(props: ChatContainerProps) {
                 welcomeConfig?.showMoreText ??
                 emptyContainerProps.showMoreText ??
                 i18n('empty-state-show-more'),
-            onSuggestionClick: async (content: string, suggestionId?: string) => {
+            onSuggestionClick: async (
+                content: string,
+                suggestionId?: string,
+                suggestionData?: Record<string, unknown>,
+            ) => {
+                const suggestion = toSuggestionContext(suggestionId, suggestionData);
+
                 await onSendMessage({
                     content,
-                    ...(suggestionId && {metadata: {suggestion_id: suggestionId}}),
+                    ...(suggestion && {suggestion}),
                 });
             },
         };

--- a/src/components/pages/ChatContainer/README.md
+++ b/src/components/pages/ChatContainer/README.md
@@ -434,17 +434,25 @@ interface WelcomeConfig {
 
 #### Suggestions Properties
 
-The `suggestions` array uses the `SuggestionsItem` type. When a suggestion is clicked, its optional `onClick` callback is called before its `title` value is sent as the message content.
+The `suggestions` array uses the `SuggestionsItem` type. When a suggestion is clicked, its optional `onClick` callback is called before `onSendMessage` is invoked with the suggestion context.
 
 ```tsx
 welcomeConfig={{
   suggestions: [{
     id: 'explain-cloud',
     title: 'Explain Yandex Cloud',
-    onClick: (content, id) => {
-      sendMetric('welcome_suggestion_click', {content, id});
+    data: {source: 'welcome-screen', category: 'getting-started'},
+    onClick: (content, id, data) => {
+      sendMetric('welcome_suggestion_click', {content, id, data});
     },
   }],
+}}
+
+// In onSendMessage:
+onSendMessage={async ({content, suggestion}) => {
+  // content — suggestion title
+  // suggestion?.id — stable identifier
+  // suggestion?.data — optional custom payload from the suggestion item
 }}
 ```
 
@@ -452,9 +460,10 @@ welcomeConfig={{
 
 - **`title`** (required): The text displayed on the button and sent as message content
 - **`id`** (optional): Unique identifier for the suggestion
+- **`data`** (optional): Custom payload passed through to click handlers and `TSubmitData.suggestion.data`
 - **`view`** (optional): Button styling - `'normal'`, `'action'`, `'outlined'`, `'flat'`, `'flat-secondary'`, `'outlined-info'`
 - **`icon`** (optional): Icon position - `'left'` displays ChevronLeft, `'right'` displays ChevronRight
-- **`onClick`** (optional): Additional callback called with the suggestion title and optional ID before the default click handler
+- **`onClick`** (optional): Additional callback called with `title`, optional `id`, and optional `data` before the default click handler
 
 **Text Wrapping:**
 

--- a/src/components/pages/ChatContainer/__stories__/ChatContainer.stories.tsx
+++ b/src/components/pages/ChatContainer/__stories__/ChatContainer.stories.tsx
@@ -22,6 +22,7 @@ export {
     Playground,
     EmptyState,
     WithSuggestionItemCallback,
+    WithSuggestionDataCallback,
     WithMessages,
     WithStreaming,
     WithVirtualizedStreaming,

--- a/src/components/pages/ChatContainer/__stories__/parts/basic.tsx
+++ b/src/components/pages/ChatContainer/__stories__/parts/basic.tsx
@@ -178,12 +178,46 @@ export const WithSuggestionItemCallback: Story = {
                             },
                         ],
                     }}
-                    onSendMessage={async ({content, metadata}) => {
-                        const suggestionId =
-                            typeof metadata?.suggestion_id === 'string'
-                                ? metadata.suggestion_id
-                                : '';
+                    onSendMessage={async ({content, suggestion}) => {
+                        const suggestionId = suggestion?.id ?? '';
                         setSentSuggestion(`${content}:${suggestionId}`);
+                    }}
+                />
+            </>
+        );
+    },
+    decorators: defaultDecorators,
+};
+
+/**
+ * Empty state fixture for verifying suggestion data is passed to onSendMessage.
+ */
+export const WithSuggestionDataCallback: Story = {
+    args: {
+        messages: [],
+        welcomeConfig: {
+            suggestions: [
+                {
+                    id: 'suggestion-1',
+                    title: 'Suggestion content',
+                    data: {additional_prompt: 'Focus on billing'},
+                },
+            ],
+        },
+    },
+    render: (args) => {
+        const [sentSuggestion, setSentSuggestion] = useState('');
+
+        return (
+            <>
+                <div data-qa="welcome-suggestion-send">{sentSuggestion}</div>
+                <ChatContainer
+                    {...args}
+                    onSendMessage={async ({content, suggestion}) => {
+                        const additionalPrompt = suggestion?.data?.additional_prompt;
+                        setSentSuggestion(
+                            `${content}:${suggestion?.id ?? ''}:${typeof additionalPrompt === 'string' ? additionalPrompt : ''}`,
+                        );
                     }}
                 />
             </>

--- a/src/components/pages/ChatContainer/__stories__/parts/basic.tsx
+++ b/src/components/pages/ChatContainer/__stories__/parts/basic.tsx
@@ -178,8 +178,12 @@ export const WithSuggestionItemCallback: Story = {
                             },
                         ],
                     }}
-                    onSendMessage={async ({content}) => {
-                        setSentSuggestion(content);
+                    onSendMessage={async ({content, metadata}) => {
+                        const suggestionId =
+                            typeof metadata?.suggestion_id === 'string'
+                                ? metadata.suggestion_id
+                                : '';
+                        setSentSuggestion(`${content}:${suggestionId}`);
                     }}
                 />
             </>

--- a/src/components/pages/ChatContainer/__tests__/ChatContainer.visual.spec.tsx
+++ b/src/components/pages/ChatContainer/__tests__/ChatContainer.visual.spec.tsx
@@ -170,7 +170,7 @@ test.describe('ChatContainer', {tag: '@ChatContainer'}, () => {
             'Suggestion content:suggestion-1',
         );
         await expect(page.locator('[data-qa="welcome-suggestion-send"]')).toHaveText(
-            'Suggestion content',
+            'Suggestion content:suggestion-1',
         );
     });
 

--- a/src/components/pages/ChatContainer/__tests__/ChatContainer.visual.spec.tsx
+++ b/src/components/pages/ChatContainer/__tests__/ChatContainer.visual.spec.tsx
@@ -174,6 +174,16 @@ test.describe('ChatContainer', {tag: '@ChatContainer'}, () => {
         );
     });
 
+    test('should pass suggestion data to onSendMessage on welcome click', async ({mount, page}) => {
+        await mount(<ChatContainerStories.WithSuggestionDataCallback />);
+
+        await page.getByRole('button', {name: 'Suggestion content'}).click();
+
+        await expect(page.locator('[data-qa="welcome-suggestion-send"]')).toHaveText(
+            'Suggestion content:suggestion-1:Focus on billing',
+        );
+    });
+
     test('should send message via prompt input', async ({mount, page}) => {
         await mount(<ChatContainerStories.EmptyState />);
 

--- a/src/components/templates/EmptyContainer/EmptyContainer.tsx
+++ b/src/components/templates/EmptyContainer/EmptyContainer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {ArrowRotateRight} from '@gravity-ui/icons';
 import {Button, Text} from '@gravity-ui/uikit';
 
-import type {SuggestionsItem} from '../../../types/common';
+import type {SuggestionClickHandler, SuggestionsItem} from '../../../types/common';
 import {block} from '../../../utils/cn';
 import {Suggestions} from '../../molecules/Suggestions';
 
@@ -50,7 +50,7 @@ export interface EmptyContainerProps {
     /** Array of suggestion items */
     suggestions?: Suggestion[];
     /** Callback when a suggestion is clicked */
-    onSuggestionClick?: (content: string, id?: string) => void;
+    onSuggestionClick?: SuggestionClickHandler;
     /** Alignment configuration for image, title, and description */
     alignment?: AlignmentConfig;
     /** Layout orientation for suggestions: 'grid' for horizontal, 'list' for vertical */

--- a/src/components/templates/EmptyContainer/README.md
+++ b/src/components/templates/EmptyContainer/README.md
@@ -129,21 +129,21 @@ import {EmptyContainer} from '@gravity-ui/aikit';
 
 ## Props
 
-| Prop                | Type                                     | Required | Default  | Description                                                                    |
-| ------------------- | ---------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------ |
-| `image`             | `ReactNode`                              | -        | -        | Image or icon to display at the top                                            |
-| `title`             | `string \| ReactNode`                    | -        | -        | Title text or custom React element for the welcome screen                      |
-| `description`       | `string \| ReactNode`                    | -        | -        | Description text or custom React element                                       |
-| `suggestionTitle`   | `string`                                 | -        | -        | Title for the suggestions section                                              |
-| `suggestions`       | `Suggestion[]`                           | -        | `[]`     | Array of suggestion items                                                      |
-| `onSuggestionClick` | `(content: string, id?: string) => void` | -        | -        | Callback when a suggestion is clicked                                          |
-| `alignment`         | `AlignmentConfig`                        | -        | -        | Alignment configuration for image, title, and description                      |
-| `layout`            | `'grid' \| 'list'`                       | -        | `'grid'` | Layout orientation for suggestions: 'grid' for horizontal, 'list' for vertical |
-| `wrapText`          | `boolean`                                | -        | `false`  | Enable text wrapping inside suggestion buttons instead of ellipsis             |
-| `showMore`          | `() => void`                             | -        | -        | Callback for showing more suggestions (displays a button)                      |
-| `showMoreText`      | `string`                                 | -        | -        | Custom text for the show more button (overrides i18n localization)             |
-| `className`         | `string`                                 | -        | -        | Additional CSS class                                                           |
-| `qa`                | `string`                                 | -        | -        | QA/test identifier                                                             |
+| Prop                | Type                     | Required | Default  | Description                                                                    |
+| ------------------- | ------------------------ | -------- | -------- | ------------------------------------------------------------------------------ |
+| `image`             | `ReactNode`              | -        | -        | Image or icon to display at the top                                            |
+| `title`             | `string \| ReactNode`    | -        | -        | Title text or custom React element for the welcome screen                      |
+| `description`       | `string \| ReactNode`    | -        | -        | Description text or custom React element                                       |
+| `suggestionTitle`   | `string`                 | -        | -        | Title for the suggestions section                                              |
+| `suggestions`       | `Suggestion[]`           | -        | `[]`     | Array of suggestion items                                                      |
+| `onSuggestionClick` | `SuggestionClickHandler` | -        | -        | Callback when a suggestion is clicked                                          |
+| `alignment`         | `AlignmentConfig`        | -        | -        | Alignment configuration for image, title, and description                      |
+| `layout`            | `'grid' \| 'list'`       | -        | `'grid'` | Layout orientation for suggestions: 'grid' for horizontal, 'list' for vertical |
+| `wrapText`          | `boolean`                | -        | `false`  | Enable text wrapping inside suggestion buttons instead of ellipsis             |
+| `showMore`          | `() => void`             | -        | -        | Callback for showing more suggestions (displays a button)                      |
+| `showMoreText`      | `string`                 | -        | -        | Custom text for the show more button (overrides i18n localization)             |
+| `className`         | `string`                 | -        | -        | Additional CSS class                                                           |
+| `qa`                | `string`                 | -        | -        | QA/test identifier                                                             |
 
 ### AlignmentConfig Type
 
@@ -201,7 +201,7 @@ The layout consists of two main areas:
 
 ## Suggestions Behavior
 
-When a suggestion is clicked, the `onSuggestionClick` callback will be called with the suggestion content and ID (if provided).
+When a suggestion is clicked, the `onSuggestionClick` callback will be called with the suggestion `title`, optional `id`, and optional `data` payload.
 
 ### Show More Button
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -17,6 +17,15 @@ export type ActionConfig = {
 export type Action = ActionConfig | React.ReactNode;
 
 /**
+ * Callback invoked when a suggestion is clicked
+ */
+export type SuggestionClickHandler = (
+    content: string,
+    id?: string,
+    data?: Record<string, unknown>,
+) => void | Promise<void>;
+
+/**
  * Single suggestion item displayed as a button
  */
 export type SuggestionsItem = {
@@ -24,10 +33,12 @@ export type SuggestionsItem = {
     id?: string;
     /** Title text to display on the button */
     title: string;
+    /** Optional payload passed to click handlers and submit data */
+    data?: Record<string, unknown>;
     /** Button view */
     view?: ButtonButtonProps['view'];
     /** Icon position: 'left' for ChevronLeft, 'right' for ChevronRight */
     icon?: 'left' | 'right';
     /** Additional callback invoked when this suggestion is clicked */
-    onClick?: (content: string, id?: string) => void | Promise<void>;
+    onClick?: SuggestionClickHandler;
 };

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -103,10 +103,18 @@ export type BaseMessageProps<TMessage = unknown> = {
 
 export type TMessageMetadata = Record<string, unknown>;
 
+/** Context passed when a message is sent via suggestion click */
+export type TSuggestionContext = {
+    id?: string;
+    data?: Record<string, unknown>;
+};
+
 export type TSubmitData = {
     content: string;
     attachments?: File[];
     metadata?: TMessageMetadata;
+    /** Set when the message is sent by clicking a suggestion */
+    suggestion?: TSuggestionContext;
 };
 
 export type TMessageRole = 'user' | 'assistant' | 'system';


### PR DESCRIPTION

- Add optional `data` payload to `SuggestionsItem`
- Introduce `SuggestionClickHandler` and forward `id` + `data` through suggestion click handlers
- Add `TSubmitData.suggestion` (`{ id?, data? }`) for welcome suggestion clicks in `ChatContainer`
- Fix `PromptInput` not forwarding `id` and `data` to `onSuggestionClick`
- Update component READMEs (`Suggestions`, `PromptInput`, `EmptyContainer`, `ChatContainer`)