### PR TITLE
fix(PromptInputFooter): align custom content with submit button

### DIFF
--- a/src/components/molecules/PromptInputFooter/PromptInputFooter.scss
+++ b/src/components/molecules/PromptInputFooter/PromptInputFooter.scss
@@ -4,7 +4,7 @@ $block: '.#{variables.$ns}prompt-input-footer';
 
 #{$block} {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: space-between;
     align-self: stretch;
     gap: var(--g-spacing-1);
@@ -20,6 +20,7 @@ $block: '.#{variables.$ns}prompt-input-footer';
     &__content {
         display: flex;
         align-items: center;
+        align-self: center;
         flex: 1;
         min-width: 0;
     }


### PR DESCRIPTION
## Summary

- restore bottom alignment for the submit button
- center custom footer content relative to the submit button

## Testing

- npm run lint
- npm run playwright:docker -- --grep "@PromptInputFooter"