### PR TITLE
fix(PromptInput): place caret at end on initial focus

### DIFF
--- a/src/components/molecules/PromptInputBody/PromptInputBody.tsx
+++ b/src/components/molecules/PromptInputBody/PromptInputBody.tsx
@@ -87,7 +87,11 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
 
             // Let the browser finish pointer-based caret placement before overriding it.
             requestAnimationFrame(() => {
-                if (textarea.isConnected && textarea.ownerDocument.activeElement === textarea) {
+                if (
+                    textarea.isConnected &&
+                    textarea.ownerDocument.activeElement === textarea &&
+                    textarea.selectionStart === textarea.selectionEnd
+                ) {
                     const caretPosition = textarea.value.length;
                     textarea.setSelectionRange(caretPosition, caretPosition);
                 }

--- a/src/components/molecules/PromptInputBody/PromptInputBody.tsx
+++ b/src/components/molecules/PromptInputBody/PromptInputBody.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, forwardRef} from 'react';
+import {ReactNode, forwardRef, useRef} from 'react';
 
 import type {TextAreaProps} from '@gravity-ui/uikit';
 import {TextArea} from '@gravity-ui/uikit';
@@ -71,6 +71,28 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
         } = props;
 
         const resolvedSize = useMobileControlSize(size, 'l', 'xl');
+        const hasHandledInitialFocusRef = useRef(false);
+
+        const handleFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+            if (hasHandledInitialFocusRef.current) {
+                return;
+            }
+
+            hasHandledInitialFocusRef.current = true;
+
+            const textarea = event.currentTarget;
+            if (!textarea.value) {
+                return;
+            }
+
+            // Let the browser finish pointer-based caret placement before overriding it.
+            requestAnimationFrame(() => {
+                if (textarea.isConnected && textarea.ownerDocument.activeElement === textarea) {
+                    const caretPosition = textarea.value.length;
+                    textarea.setSelectionRange(caretPosition, caretPosition);
+                }
+            });
+        };
 
         // If custom content is provided, render it
         if (children) {
@@ -94,6 +116,7 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
                     autoFocus={autoFocus}
                     disabled={disabledInput}
                     onUpdate={onChange}
+                    onFocus={handleFocus}
                     onKeyDown={onKeyDown}
                     view="clear"
                     className={b('textarea')}

--- a/src/components/molecules/PromptInputBody/PromptInputBody.tsx
+++ b/src/components/molecules/PromptInputBody/PromptInputBody.tsx
@@ -10,6 +10,19 @@ import './PromptInputBody.scss';
 
 const b = block('prompt-input-body');
 
+const scheduleCaretAtEndIfCollapsed = (textarea: HTMLTextAreaElement) => {
+    requestAnimationFrame(() => {
+        if (
+            textarea.isConnected &&
+            textarea.ownerDocument.activeElement === textarea &&
+            textarea.selectionStart === textarea.selectionEnd
+        ) {
+            const caretPosition = textarea.value.length;
+            textarea.setSelectionRange(caretPosition, caretPosition);
+        }
+    });
+};
+
 /**
  * Props for the PromptInputBody component
  */
@@ -72,6 +85,29 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
 
         const resolvedSize = useMobileControlSize(size, 'l', 'xl');
         const hasHandledInitialFocusRef = useRef(false);
+        const pendingInitialPointerIdRef = useRef<number | null>(null);
+
+        const handlePointerDown = (event: React.PointerEvent<HTMLTextAreaElement>) => {
+            pendingInitialPointerIdRef.current =
+                !hasHandledInitialFocusRef.current && event.isPrimary && event.button === 0
+                    ? event.pointerId
+                    : null;
+        };
+
+        const handlePointerUp = (event: React.PointerEvent<HTMLTextAreaElement>) => {
+            if (pendingInitialPointerIdRef.current !== event.pointerId) {
+                return;
+            }
+
+            pendingInitialPointerIdRef.current = null;
+            scheduleCaretAtEndIfCollapsed(event.currentTarget);
+        };
+
+        const handlePointerCancel = (event: React.PointerEvent<HTMLTextAreaElement>) => {
+            if (pendingInitialPointerIdRef.current === event.pointerId) {
+                pendingInitialPointerIdRef.current = null;
+            }
+        };
 
         const handleFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
             if (hasHandledInitialFocusRef.current) {
@@ -82,20 +118,13 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
 
             const textarea = event.currentTarget;
             if (!textarea.value) {
+                pendingInitialPointerIdRef.current = null;
                 return;
             }
 
-            // Let the browser finish pointer-based caret placement before overriding it.
-            requestAnimationFrame(() => {
-                if (
-                    textarea.isConnected &&
-                    textarea.ownerDocument.activeElement === textarea &&
-                    textarea.selectionStart === textarea.selectionEnd
-                ) {
-                    const caretPosition = textarea.value.length;
-                    textarea.setSelectionRange(caretPosition, caretPosition);
-                }
-            });
+            if (pendingInitialPointerIdRef.current === null) {
+                scheduleCaretAtEndIfCollapsed(textarea);
+            }
         };
 
         // If custom content is provided, render it
@@ -127,6 +156,9 @@ export const PromptInputBody = forwardRef<HTMLTextAreaElement, PromptInputBodyPr
                     controlProps={{
                         className: b('textarea-control', inputClassName),
                         maxLength,
+                        onPointerDown: handlePointerDown,
+                        onPointerUp: handlePointerUp,
+                        onPointerCancel: handlePointerCancel,
                     }}
                 />
             </div>

--- a/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
+++ b/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
@@ -99,6 +99,23 @@ test.describe('PromptInput', {tag: '@PromptInput'}, () => {
         await expect(textarea).toHaveJSProperty('selectionEnd', 4);
     });
 
+    test('should preserve explicit selection on the first focus', async ({mount, page}) => {
+        await mount(<PromptInputStories.Playground initialValue="some" />);
+
+        const textarea = page.locator('textarea');
+
+        await textarea.selectText();
+        await page.evaluate(
+            () =>
+                new Promise<void>((resolve) => {
+                    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+                }),
+        );
+
+        await expect(textarea).toHaveJSProperty('selectionStart', 0);
+        await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+    });
+
     test('should render with top panel', async ({mount, expectScreenshot}) => {
         await mount(<PromptInputStories.WithTopPanel />);
 

--- a/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
+++ b/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
@@ -64,6 +64,41 @@ test.describe('PromptInput', {tag: '@PromptInput'}, () => {
         await expectScreenshot();
     });
 
+    test('should place caret at the end on the first focus only', async ({mount, page}) => {
+        await mount(<PromptInputStories.Playground initialValue="some" />);
+
+        const textarea = page.locator('textarea');
+        const bounds = await textarea.boundingBox();
+        if (!bounds) {
+            throw new Error('Expected the textarea to be visible');
+        }
+
+        await textarea.click({position: {x: bounds.width - 2, y: 1}});
+
+        await expect(textarea).toBeFocused();
+        await expect(textarea).toHaveJSProperty('selectionStart', 4);
+        await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+
+        await textarea.press('Tab');
+        await expect(textarea).not.toBeFocused();
+        await textarea.click({position: {x: 2, y: bounds.height / 2}});
+
+        await expect(textarea).toHaveJSProperty('selectionStart', 0);
+        await expect(textarea).toHaveJSProperty('selectionEnd', 0);
+    });
+
+    test('should place caret at the end on autofocus', async ({mount, page}) => {
+        await mount(
+            <PromptInputStories.Playground initialValue="some" bodyProps={{autoFocus: true}} />,
+        );
+
+        const textarea = page.locator('textarea');
+
+        await expect(textarea).toBeFocused();
+        await expect(textarea).toHaveJSProperty('selectionStart', 4);
+        await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+    });
+
     test('should render with top panel', async ({mount, expectScreenshot}) => {
         await mount(<PromptInputStories.WithTopPanel />);
 

--- a/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
+++ b/src/components/organisms/PromptInput/__tests__/PromptInput.visual.spec.tsx
@@ -116,6 +116,31 @@ test.describe('PromptInput', {tag: '@PromptInput'}, () => {
         await expect(textarea).toHaveJSProperty('selectionEnd', 4);
     });
 
+    test('should preserve a slow pointer selection on the first focus', async ({mount, page}) => {
+        await mount(<PromptInputStories.Playground initialValue="some" />);
+
+        const textarea = page.locator('textarea');
+        const bounds = await textarea.boundingBox();
+        if (!bounds) {
+            throw new Error('Expected the textarea to be visible');
+        }
+
+        const pointerY = bounds.y + bounds.height / 2;
+        await page.mouse.move(bounds.x + 2, pointerY);
+        await page.mouse.down();
+        await page.evaluate(
+            () =>
+                new Promise<void>((resolve) => {
+                    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+                }),
+        );
+        await page.mouse.move(bounds.x + bounds.width - 2, pointerY, {steps: 10});
+        await page.mouse.up();
+
+        await expect(textarea).toHaveJSProperty('selectionStart', 0);
+        await expect(textarea).toHaveJSProperty('selectionEnd', 4);
+    });
+
     test('should render with top panel', async ({mount, expectScreenshot}) => {
         await mount(<PromptInputStories.WithTopPanel />);
 


### PR DESCRIPTION
## What changed

- Move the caret to the end of a non-empty value on the first focus after mount.
- Defer pointer-originated initial focus handling until `pointerup`, after the browser has completed a click or drag selection.
- Preserve native caret placement on subsequent focus and click events.
- Preserve explicit text selections created during the first focus.
- Cover pointer focus, slow pointer selection, refocus, autofocus, and explicit selection with regression tests based on the existing Playground story.

## Verification

- `npm run playwright:docker -- --grep "@PromptInput"` — 42 passed
- `npm run playwright:docker` — 420 passed
- `npm run playwright:docker -- --grep "caret|autofocus|selection" --repeat-each=20` — 100 passed
- `npm test` — 281 client and 19 server tests passed
- `npm run lint`
- `npm run build`
- Chromium, Firefox, and WebKit Storybook interaction matrix — 48/48 scenarios passed
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

Closes #152