### PR TITLE
fix(useMarkdownTransform): import the split diplodoc runtime, not the combined bundle

### DIFF
--- a/src/hooks/useMarkdownTransform.ts
+++ b/src/hooks/useMarkdownTransform.ts
@@ -3,7 +3,21 @@ import {useMemo, useRef} from 'react';
 import {isWithMdxArtifacts} from '@diplodoc/mdx-extension';
 import type {MdxArtifacts} from '@diplodoc/mdx-extension';
 import transform from '@diplodoc/transform';
-import '@diplodoc/transform/dist/js/yfm.js';
+// The SPLIT runtime, not the combined `dist/js/yfm.js`, matching what
+// @gravity-ui/markdown-editor imports. Both forms attach global document
+// listeners at import time with no guard against double registration, so an
+// app using aikit alongside markdown-editor (or importing the runtime itself,
+// which is documented in split form) bundled two distinct modules with
+// identical side effects. Every listener fired twice: a YFM term click opened
+// the popup and then immediately hit the isSameTerm branch and closed it, so
+// term popups never stayed open, and code-copy buttons double-fired. Importing
+// the same files lets the bundler dedupe to one runtime instance.
+//
+// Order between the two is irrelevant - each is a self-contained IIFE with
+// its own copy of the shared helpers and no import-time dependency on the
+// other - so they are listed in the order import/order wants.
+import '@diplodoc/transform/dist/js/_yfm-only.js';
+import '@diplodoc/transform/dist/js/base.js';
 import {OptionsType} from '@diplodoc/transform/lib/typings';
 
 import {areOptionsEqual, mergeMarkdownTransformOptions} from '../utils/markdownUtils';


### PR DESCRIPTION
Fixes #186.

## Change

```diff
-import '@diplodoc/transform/dist/js/yfm.js';
+import '@diplodoc/transform/dist/js/_yfm-only.js';
+import '@diplodoc/transform/dist/js/base.js';
```

Exactly the fix the issue proposes — align with what `@gravity-ui/markdown-editor` imports, so a bundler resolves one runtime instance instead of two distinct modules with identical side effects.

## Verified the overlap rather than taking it on trust

Against `@diplodoc/transform@4.64.1`, both forms carry the same import-time registrations:

| file | size | `addEventListener` | `yfm-term` |
|---|---|---|---|
| `yfm.js` (combined) | 44 KB | 20 | 2 |
| `base.js` | 16 KB | 6 | 2 |
| `_yfm-only.js` | 8.7 KB | 5 | 2 |

The split pair covers what the combined bundle does, and both register the term handler — so importing one of each form double-registers it, which is the popup-opens-then-closes symptom.

## On import order

The issue's proposed snippet lists `base.js` first; the reporter's own workaround shim lists `_yfm-only` first. I checked whether it matters: each file is a self-contained IIFE with its own bundled copy of the shared helpers (`getEventTarget`, `isCustom`) and no import-time reference to the other, so the order is functionally irrelevant.

Given that, I used the order `import/order` wants — `_` sorts before `b` — so the file lints clean without a disable comment. Noted in a comment above the imports so the next person doesn't "fix" it back and hit the lint error.

## Checks

```
npm run typecheck                              # clean
npx eslint src/hooks/useMarkdownTransform.ts   # clean
npx prettier --check ...                       # clean
npm run test:unit                              # 28 suites, 281 tests passed
```

## One thing I could not verify locally

`@gravity-ui/markdown-editor` is not in this repo's dependency tree, so I could not confirm first-hand that it imports the split form — that part is taken from the report. The change is safe regardless (the split pair is equivalent to the combined bundle here), but if markdown-editor has since moved to the combined form, this would want revisiting.
