### PR TITLE
fix(mdx): discover CSP nonce from the document

### DIFF
--- a/src/components/atoms/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/atoms/MarkdownRenderer/MarkdownRenderer.tsx
@@ -28,7 +28,7 @@ export interface MarkdownRendererMdxOptions {
     components: MDXComponents;
     /** Optional list of tag names to limit which components are processed as MDX. */
     tagNames?: string[];
-    /** CSP nonce applied to scripts that execute compiled MDX artifacts. */
+    /** CSP nonce applied to compiled MDX scripts. Defaults to a nonce found in the document. */
     nonce?: string;
 }
 

--- a/src/components/atoms/MarkdownRenderer/MdxPortals.tsx
+++ b/src/components/atoms/MarkdownRenderer/MdxPortals.tsx
@@ -7,7 +7,7 @@ import type {MDXComponents, MDXModule, MDXProps} from 'mdx/types';
 import * as runtime from 'react/jsx-runtime';
 
 import {MdxDataContext} from './MdxContext';
-import {asyncExecuteCode} from './asyncExecuteCode';
+import {asyncExecuteCode, resolveCspNonce} from './asyncExecuteCode';
 
 interface MdxLoaderState extends IdMdxComponentLoader {
     idMdx?: Record<string, string>;
@@ -16,10 +16,11 @@ interface MdxLoaderState extends IdMdxComponentLoader {
 
 function useMdxComponentLoader(mdxArtifacts: MdxArtifacts | undefined, nonce?: string) {
     const idMdx = mdxArtifacts?.idMdx;
+    const resolvedNonce = resolveCspNonce(nonce);
     const [state, setState] = useState<MdxLoaderState>({isSuccess: false});
 
     useEffect(() => {
-        if (!nonce) {
+        if (!resolvedNonce) {
             return () => undefined;
         }
 
@@ -32,7 +33,7 @@ function useMdxComponentLoader(mdxArtifacts: MdxArtifacts | undefined, nonce?: s
                 for (const [artifactId, code] of Object.entries(idMdx ?? {})) {
                     const fn = await asyncExecuteCode<(jsxRuntime: typeof runtime) => MDXModule>(
                         code,
-                        nonce,
+                        resolvedNonce,
                     );
 
                     if (!isActive) {
@@ -43,11 +44,11 @@ function useMdxComponentLoader(mdxArtifacts: MdxArtifacts | undefined, nonce?: s
                 }
 
                 if (isActive) {
-                    setState({idMdx, nonce, data, isSuccess: true});
+                    setState({idMdx, nonce: resolvedNonce, data, isSuccess: true});
                 }
             } catch {
                 if (isActive) {
-                    setState({idMdx, nonce, isSuccess: false});
+                    setState({idMdx, nonce: resolvedNonce, isSuccess: false});
                 }
             }
         })();
@@ -55,13 +56,13 @@ function useMdxComponentLoader(mdxArtifacts: MdxArtifacts | undefined, nonce?: s
         return () => {
             isActive = false;
         };
-    }, [idMdx, nonce]);
+    }, [idMdx, resolvedNonce]);
 
-    if (!nonce) {
+    if (!resolvedNonce) {
         return undefined;
     }
 
-    if (state.idMdx !== idMdx || state.nonce !== nonce) {
+    if (state.idMdx !== idMdx || state.nonce !== resolvedNonce) {
         return {isSuccess: false};
     }
 
@@ -77,7 +78,7 @@ export interface MdxPortalsProps {
     components?: MDXComponents;
     /** Artifacts collected by the MDX transform, required to hydrate the components. */
     mdxArtifacts?: MdxArtifacts;
-    /** CSP nonce applied to scripts that execute compiled MDX artifacts. */
+    /** CSP nonce applied to compiled MDX scripts. Defaults to a nonce found in the document. */
     nonce?: string;
     /** Arbitrary value exposed to the MDX components through {@link MdxDataContext}. */
     mdxContext?: Record<string, unknown>;

--- a/src/components/atoms/MarkdownRenderer/README.md
+++ b/src/components/atoms/MarkdownRenderer/README.md
@@ -52,7 +52,7 @@ This block is rendered by a **React component**.
     components: {Callout},
     // Optional: only treat these tags as MDX components
     tagNames: ['Callout'],
-    // Required when the service enforces a nonce-based script-src CSP
+    // Optional: pass the nonce explicitly instead of discovering it from the page
     nonce: cspNonce,
   }}
 />;
@@ -63,10 +63,11 @@ This block is rendered by a **React component**.
 > blocks and its artifacts must be collected from the whole document.
 
 Compiled MDX artifacts are executed through an inline `<script>` instead of `eval` or
-`new Function`. Services with a nonce-based `script-src` Content Security Policy must pass the
-nonce through `mdxOptions.nonce`; the renderer applies it to every temporary MDX script.
-When `nonce` is omitted, the renderer preserves the extension's legacy `new Function` execution
-path for backward compatibility.
+`new Function`. Services with a nonce-based `script-src` Content Security Policy can pass the
+nonce through `mdxOptions.nonce`; the renderer applies it to every temporary MDX script. When the
+option is omitted, the renderer reuses the nonce from the first `<script nonce="...">` in the
+document. If no nonce is available, the renderer preserves the extension's legacy `new Function`
+execution path for backward compatibility.
 
 ### Per-message context (`mdxContext` + `useMdxContext`)
 
@@ -128,7 +129,7 @@ instead of a static value. It is called with the concrete message and its return
 | ------------ | --------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
 | `components` | `MDXComponents` | Yes      | -       | Map of tag name → React component used to render embedded MDX/JSX in the content (e.g. `{Callout, StatusBadge}`). |
 | `tagNames`   | `string[]`      | -        | -       | Restricts which tags are processed as MDX components. When omitted, the extension's default detection is used.    |
-| `nonce`      | `string`        | -        | -       | CSP nonce applied to temporary inline scripts. When omitted, MDX uses the legacy `new Function` execution path.   |
+| `nonce`      | `string`        | -        | -       | CSP nonce applied to temporary inline scripts. When omitted, it is discovered from an existing script.            |
 
 ## Styling
 

--- a/src/components/atoms/MarkdownRenderer/README.md
+++ b/src/components/atoms/MarkdownRenderer/README.md
@@ -65,9 +65,9 @@ This block is rendered by a **React component**.
 Compiled MDX artifacts are executed through an inline `<script>` instead of `eval` or
 `new Function`. Services with a nonce-based `script-src` Content Security Policy can pass the
 nonce through `mdxOptions.nonce`; the renderer applies it to every temporary MDX script. When the
-option is omitted, the renderer reuses the nonce from the first `<script nonce="...">` in the
-document. If no nonce is available, the renderer preserves the extension's legacy `new Function`
-execution path for backward compatibility.
+option is omitted, the renderer reuses the first non-empty nonce from a
+`<script nonce="...">` in the document. If no nonce is available, the renderer preserves the
+extension's legacy `new Function` execution path for backward compatibility.
 
 ### Per-message context (`mdxContext` + `useMdxContext`)
 

--- a/src/components/atoms/MarkdownRenderer/__tests__/MdxPortals.unit.test.tsx
+++ b/src/components/atoms/MarkdownRenderer/__tests__/MdxPortals.unit.test.tsx
@@ -1,5 +1,5 @@
 import {useMdx} from '@diplodoc/mdx-extension';
-import {render} from '@testing-library/react';
+import {render, waitFor} from '@testing-library/react';
 
 import {MdxPortals} from '../MdxPortals';
 
@@ -10,7 +10,67 @@ jest.mock('@diplodoc/mdx-extension', () => ({
 const mockedUseMdx = jest.mocked(useMdx);
 
 describe('MdxPortals', () => {
-    test('should use the legacy MDX loader when nonce is not provided', () => {
+    afterEach(() => {
+        mockedUseMdx.mockClear();
+        document.head.querySelectorAll('script[data-test-csp-nonce]').forEach((script) => {
+            script.remove();
+        });
+    });
+
+    test('should discover the CSP nonce from an existing script', async () => {
+        const script = document.createElement('script');
+        script.dataset.testCspNonce = 'true';
+        script.nonce = 'page-nonce';
+        document.head.appendChild(script);
+
+        render(
+            <MdxPortals
+                refCtr={{current: document.createElement('div')}}
+                html=""
+                mdxArtifacts={{idMdx: {}, idTagName: {}}}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(mockedUseMdx).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    idMdxComponentLoader: expect.objectContaining({
+                        isSuccess: true,
+                        nonce: 'page-nonce',
+                    }),
+                }),
+            );
+        });
+    });
+
+    test('should use the explicitly provided nonce', async () => {
+        const script = document.createElement('script');
+        script.dataset.testCspNonce = 'true';
+        script.nonce = 'page-nonce';
+        document.head.appendChild(script);
+
+        render(
+            <MdxPortals
+                refCtr={{current: document.createElement('div')}}
+                html=""
+                mdxArtifacts={{idMdx: {}, idTagName: {}}}
+                nonce="explicit-nonce"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(mockedUseMdx).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    idMdxComponentLoader: expect.objectContaining({
+                        isSuccess: true,
+                        nonce: 'explicit-nonce',
+                    }),
+                }),
+            );
+        });
+    });
+
+    test('should use the legacy MDX loader when nonce is not available', () => {
         render(
             <MdxPortals
                 refCtr={{current: document.createElement('div')}}

--- a/src/components/atoms/MarkdownRenderer/__tests__/asyncExecuteCode.unit.test.ts
+++ b/src/components/atoms/MarkdownRenderer/__tests__/asyncExecuteCode.unit.test.ts
@@ -44,6 +44,10 @@ describe('asyncExecuteCode', () => {
     });
 
     test('should discover the nonce from an existing script', async () => {
+        const emptyNonceScript = document.createElement('script');
+        emptyNonceScript.setAttribute('nonce', '');
+        document.head.appendChild(emptyNonceScript);
+
         const pageScript = document.createElement('script');
         pageScript.nonce = 'page-nonce';
         document.head.appendChild(pageScript);

--- a/src/components/atoms/MarkdownRenderer/__tests__/asyncExecuteCode.unit.test.ts
+++ b/src/components/atoms/MarkdownRenderer/__tests__/asyncExecuteCode.unit.test.ts
@@ -14,6 +14,10 @@ describe('asyncExecuteCode', () => {
     });
 
     test('should execute code through a script using the provided nonce', async () => {
+        const pageScript = document.createElement('script');
+        pageScript.nonce = 'page-nonce';
+        document.head.appendChild(pageScript);
+
         const executor = () => 'result';
         let scriptSource = '';
 
@@ -37,6 +41,30 @@ describe('asyncExecuteCode', () => {
         expect(scriptSource).toContain('return "result";');
         expect(scriptSource).not.toMatch(/new Function|eval\s*\(/);
         expect((window as unknown as Record<string, unknown>)[HANDLERS_KEY]).toBeUndefined();
+    });
+
+    test('should discover the nonce from an existing script', async () => {
+        const pageScript = document.createElement('script');
+        pageScript.nonce = 'page-nonce';
+        document.head.appendChild(pageScript);
+
+        const executor = () => 'result';
+
+        jest.spyOn(document.head, 'appendChild').mockImplementation((node: Node) => {
+            const script = node as HTMLScriptElement;
+            const handlers = (window as unknown as Record<string, unknown>)[HANDLERS_KEY] as Record<
+                string,
+                ExecutionHandler<typeof executor>
+            >;
+            const [handler] = Object.values(handlers);
+
+            expect(script.nonce).toBe('page-nonce');
+            handler.resolve(executor);
+
+            return node;
+        });
+
+        await expect(asyncExecuteCode('return "result";')).resolves.toBe(executor);
     });
 
     test('should reject and clean up when the script is not executed', async () => {

--- a/src/components/atoms/MarkdownRenderer/asyncExecuteCode.ts
+++ b/src/components/atoms/MarkdownRenderer/asyncExecuteCode.ts
@@ -7,10 +7,19 @@ interface ExecutionHandler<T> {
 
 type ExecutionHandlers = Record<string, ExecutionHandler<unknown>>;
 
+export function resolveCspNonce(nonce?: string) {
+    if (nonce || typeof document === 'undefined') {
+        return nonce;
+    }
+
+    return document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce || undefined;
+}
+
 /** Executes code through a nonce-aware script without using `eval` or `new Function`. */
 export async function asyncExecuteCode<T>(code: string, nonce?: string): Promise<T> {
     const globalScope = window as unknown as Record<string, unknown>;
     const handlers = (globalScope[HANDLERS_KEY] ??= {}) as ExecutionHandlers;
+    const resolvedNonce = resolveCspNonce(nonce);
 
     let id: string;
     do {
@@ -18,8 +27,8 @@ export async function asyncExecuteCode<T>(code: string, nonce?: string): Promise
     } while (handlers[id]);
 
     const script = document.createElement('script');
-    if (nonce) {
-        script.setAttribute('nonce', nonce);
+    if (resolvedNonce) {
+        script.setAttribute('nonce', resolvedNonce);
     }
 
     const promise = new Promise<T>((resolve, reject) => {

--- a/src/components/atoms/MarkdownRenderer/asyncExecuteCode.ts
+++ b/src/components/atoms/MarkdownRenderer/asyncExecuteCode.ts
@@ -12,7 +12,13 @@ export function resolveCspNonce(nonce?: string) {
         return nonce;
     }
 
-    return document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce || undefined;
+    for (const script of document.querySelectorAll<HTMLScriptElement>('script[nonce]')) {
+        if (script.nonce) {
+            return script.nonce;
+        }
+    }
+
+    return undefined;
 }
 
 /** Executes code through a nonce-aware script without using `eval` or `new Function`. */


### PR DESCRIPTION
## What happened

Applications with a strict nonce-based Content Security Policy can fail while rendering MDX even when the page already has a valid per-request nonce.

AI Kit uses its nonce-aware MDX loader only when an integration explicitly passes `mdxOptions.nonce`. When the option is omitted, rendering falls back to the legacy loader in `@diplodoc/mdx-extension`, which executes compiled MDX through `new Function`. Browsers then reject the render because `unsafe-eval` is intentionally absent from `script-src`. The chat request itself can complete successfully; the failure happens afterwards while rendering the response.

## Why fix it here

A document protected by nonce-based CSP already exposes the active nonce through the `nonce` property of its bootstrap scripts. Requiring every integration to thread the same value through several component layers is easy to miss and can silently restore the CSP-incompatible legacy path.

Reusing the nonce that is already present in the document keeps CSP strict, removes integration-specific glue code, and preserves an explicitly supplied nonce as the highest-priority override.

## What changed

- Resolve an explicitly provided nonce first.
- Otherwise discover the first non-empty nonce from `script[nonce]` elements in the document.
- Use the resolved value in both the MDX component loader and temporary execution scripts.
- Preserve the legacy loader only when no nonce is available at all.
- Cover automatic discovery (including an empty nonce before a valid one), explicit override priority, and the no-nonce fallback with unit tests.
- Document the automatic behavior and explicit override.

## Testing

- `npm test` — 30 suites, 303 tests passed
- `npm run build`
- `npm run typecheck`
- ESLint for the changed TypeScript files
- Prettier for all changed files
- Headless Chrome check with a nonce-only `script-src` policy
