### PR TITLE
fix(styles): hide sheet title with uikit 7.48 markup

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -6,8 +6,13 @@
         max(#{$inline}, env(safe-area-inset-left, 0px));
 }
 
+// uikit 7.48 extracted the sheet content area into its own `sheet-content-area` block and
+// renamed the heading element, so both names have to be matched while the peer range spans
+// versions before and after that refactoring.
+
 @mixin sheet-hidden-title {
-    > .g-sheet__sheet-content-title {
+    > .g-sheet__sheet-content-title,
+    > .g-sheet-content-area__content-title {
         display: none;
     }
 }


### PR DESCRIPTION
uikit 7.48 extracted the sheet content area into a separate `sheet-content-area` block and renamed the visible heading from `.g-sheet__sheet-content-title` to `.g-sheet-content-area__content-title`.

The `sheet-hidden-title` mixin still matched the old name only, so `History showSheetTitle={false}` and `Header showSheetTitle={false}` stopped hiding the heading on uikit >= 7.48: the title came back in the mobile chat history sheet and in the header menu sheet and pushed the content down.

The mixin now matches both names, so it keeps working across the whole `^7.25.0` peer range.

### Why CI did not catch it

`History > mobile > should hide the sheet title but keep the accessible name` already asserts the heading is hidden, and that assertion is markup agnostic. The repo resolves uikit 7.25.0, so the rename simply never happens in the test run. Bumping the dev dependency would re-canonize a lot of snapshots, so it is left out of this fix.

### Verification

Checked in Yandex Cloud Console (uikit 7.48.3, aikit 2.20.0 with this change applied as a pnpm patch): all 16 mobile assistant integration tests pass against the reference screenshots taken before the uikit bump.
