### PR TITLE
chore(deps): run the visual tests against uikit 7.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@gravity-ui/readme-validator": "^1.3.0",
         "@gravity-ui/stylelint-config": "^4.0.1",
         "@gravity-ui/tsconfig": "^1.0.0",
-        "@gravity-ui/uikit": "^7.25.0",
+        "@gravity-ui/uikit": "^7.48.3",
         "@playwright/experimental-ct-react": "^1.56.1",
         "@playwright/test": "^1.56.1",
         "@storybook/addon-docs": "^9.0.5",
@@ -3334,30 +3334,38 @@
       "dev": true
     },
     "node_modules/@gravity-ui/uikit": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/uikit/-/uikit-7.25.0.tgz",
-      "integrity": "sha512-E2z1VOzr4KpnTZDMleXxyRHCCD8h2Pt97Tw2+HMV1X5zVsLC/t7oxYnHsk8MkuVLf69c21Dk4StQxwqSv8aCKQ==",
+      "version": "7.48.3",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/uikit/-/uikit-7.48.3.tgz",
+      "integrity": "sha512-pnN2IGSfKWxxvBUtCNHH4hEPifyZBqRc2rnWKCdUBaRBc7O+Rh46KIys/LmbFQE0Zq4Mlq2Q12oU0cE7K8cRuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@bem-react/classname": "^1.6.0",
-        "@floating-ui/react": "^0.27.12",
+        "@bem-react/classname": "^1.7.0",
+        "@floating-ui/react": "^0.27.16",
         "@gravity-ui/i18n": "^1.8.0",
-        "@gravity-ui/icons": "^2.13.0",
+        "@gravity-ui/icons": "^2.16.0",
         "@hello-pangea/dnd": "^18.0.1",
-        "@tanstack/react-virtual": "^3.13.9",
+        "@tanstack/react-virtual": "^3.13.12",
+        "@uiw/react-color": "^2.9.2",
         "blueimp-md5": "^2.19.0",
         "lodash": "^4.17.21",
-        "rc-slider": "^11.1.8",
+        "rc-slider": "^11.1.9",
         "react-transition-group": "^4.4.5",
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-window": "^1.8.11",
         "tabbable": "^6.2.0",
         "tslib": "^2.8.1",
-        "use-sync-external-store": "^1.5.0"
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
+        "@types/react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gravity-ui/uikit/node_modules/react-window": {
@@ -7214,6 +7222,442 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@uiw/color-convert": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.10.3.tgz",
+      "integrity": "sha512-5tIjb4CZzGR7K3Sshswsuuc6FOAFNFwjtF0hkhKH3f+CMauC4Akv7LPq6o9v68S7dIAeKvfj8qWg5Tc2I1TVSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color/-/react-color-2.10.3.tgz",
+      "integrity": "sha512-OezqWY4Fo8yJf8yn2sfdDS3xmAir6FBDSiDJ0tR/CoXwQ2RaQl0mZlarfb/I0aaGiJ/jAORAGStTX/G5XoB2jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3",
+        "@uiw/react-color-block": "2.10.3",
+        "@uiw/react-color-chrome": "2.10.3",
+        "@uiw/react-color-circle": "2.10.3",
+        "@uiw/react-color-colorful": "2.10.3",
+        "@uiw/react-color-compact": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-editable-input-hsla": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3",
+        "@uiw/react-color-github": "2.10.3",
+        "@uiw/react-color-hue": "2.10.3",
+        "@uiw/react-color-material": "2.10.3",
+        "@uiw/react-color-name": "2.10.3",
+        "@uiw/react-color-saturation": "2.10.3",
+        "@uiw/react-color-shade-slider": "2.10.3",
+        "@uiw/react-color-sketch": "2.10.3",
+        "@uiw/react-color-slider": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3",
+        "@uiw/react-color-wheel": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-alpha": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-alpha/-/react-color-alpha-2.10.3.tgz",
+      "integrity": "sha512-82wtNRmEW5uZV2hmw5SYZKPIZjN6aqm8/CZOg8KXfx8eoIqpbjrRBwABggPO/O5Dj2JNAPC4eYyHslE24Pxy8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-drag-event-interactive": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-block": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-block/-/react-color-block-2.10.3.tgz",
+      "integrity": "sha512-TVwU/bfpt51kWqL+CcQmocQrRQHAprJL/1IxjH48ZWfLqIQ1TTZVueopGBadc2CYzDygkyTWsmYpkZJZxM9YjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-chrome": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-chrome/-/react-color-chrome-2.10.3.tgz",
+      "integrity": "sha512-28qmnD19YR1wjzWe62OnwvDRhXrGy/Oq2sg/p+PBUPp8nemvq4sBX9mIToAxHtb2TiSWKCr0JapWwHZveu0tjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-editable-input-hsla": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3",
+        "@uiw/react-color-github": "2.10.3",
+        "@uiw/react-color-hue": "2.10.3",
+        "@uiw/react-color-saturation": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-circle": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.10.3.tgz",
+      "integrity": "sha512-aHO0Xf5AziEQ8PnckxIcGskPPx8Ql7BIaC7+Ngya34TDwDa/kUbEhwohn89TxNZ8ZZhG/uldTDIswMXK8Fe4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-colorful": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-colorful/-/react-color-colorful-2.10.3.tgz",
+      "integrity": "sha512-hnWr03wKNbJjNEZ4SFnwoeKNMtS2DR7rXsCv0bt17DVdBgYPZmuMTIwAR6nKFExdOwgOwXloP5KGESJYwyp2YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3",
+        "@uiw/react-color-hue": "2.10.3",
+        "@uiw/react-color-saturation": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-compact": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-compact/-/react-color-compact-2.10.3.tgz",
+      "integrity": "sha512-iXIG7idhaZ3XNFanKbVfFsL4w2GU5yWRUR+J5L1SzkXar1LTCjx7IDScweEBKnMdpPzDGiS2kTIn5anAif4ZDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input/-/react-color-editable-input-2.10.3.tgz",
+      "integrity": "sha512-QnYNpFI0p8pssYbWxIJwfmUdPwzzX0IXOAl4mU8q1HQNYoXFBGFJ4rXkJSOdauumAfOr4C8RKZlTB4/83EBBPQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input-hsla": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-hsla/-/react-color-editable-input-hsla-2.10.3.tgz",
+      "integrity": "sha512-WoWsk52MN6rvxFD1HvNTrrGRmSKwrnp0S7htd4QnKuczlLtn4qfMXVwMARdvnR7ZqC1vn7FXZpVYd+Zh3upd2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input-rgba": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-rgba/-/react-color-editable-input-rgba-2.10.3.tgz",
+      "integrity": "sha512-n0kyNTNicRKASJNWYJexfwwfbbwvOJEYGQO8tX4PivmZYQVuYZq/vqsgYG5y+VGrBYZsHFfY+0LtPS4AXlz+Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-github": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-github/-/react-color-github-2.10.3.tgz",
+      "integrity": "sha512-BLiI12utcJQMT2Ym4OeYplraHLwUtW7SJQ2IbHQA7YPEU9FYqchHv1P/6DJBZi98gFqWFll+7xotEzHCCXZP5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-hue": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-hue/-/react-color-hue-2.10.3.tgz",
+      "integrity": "sha512-dlaLaQEPXvaywc8xS8DgiYIbq4qUuI8fyERR7/bRsRXCTA9x4tFAD+lWenXcZBEhQh8HfZd1MhbvjcLzs7xpFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-material": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-material/-/react-color-material-2.10.3.tgz",
+      "integrity": "sha512-zis1x0VPBCjFmlju0Syubo6ElNIwf91CM9xilL/A3K/LGRRVuvq/PK1mGRAjFonjfTHiTlOg1Lq3NsYCaVg8LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-name": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-name/-/react-color-name-2.10.3.tgz",
+      "integrity": "sha512-BnqZebCC2lmJezs190vUtzBybjMJypFkTEav/HP3FUzHD0XSsKHOZiHENzXp+TYr0Fb7WJQXxE/dl11zkcOwVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors-named": "^1.0.1",
+        "colors-named-hex": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color-saturation": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-saturation/-/react-color-saturation-2.10.3.tgz",
+      "integrity": "sha512-iRIwNx3UTZrpV5hoQ5mcsZ8ahTXcMaGNvg8iS9JUByg+1PljwWcnqq5RNrRZJXPx+vryavefMkJLKHcPb9BLvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-drag-event-interactive": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-shade-slider": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-shade-slider/-/react-color-shade-slider-2.10.3.tgz",
+      "integrity": "sha512-WgK/JgS3oDyIzah9Jcd8uPSild6WOlYq9+jroBQ3q4ZLk+DADZ6ELaIi+tXsloxx65AaLJvXlqE0By6HAyohaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-sketch": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-sketch/-/react-color-sketch-2.10.3.tgz",
+      "integrity": "sha512-4Vua0Ti1K/uOx0E3RV0xdOfLbpc4K8zXfWZtqyjJZ7jIZpB5KNgcai+b4R47VoUpyCYf2B30iCvBuFpN3cfqYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3",
+        "@uiw/react-color-editable-input": "2.10.3",
+        "@uiw/react-color-editable-input-rgba": "2.10.3",
+        "@uiw/react-color-hue": "2.10.3",
+        "@uiw/react-color-saturation": "2.10.3",
+        "@uiw/react-color-swatch": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-slider": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-slider/-/react-color-slider-2.10.3.tgz",
+      "integrity": "sha512-aLJQPGV1/SpAWy6+U7RVqcJmhdtrdCYwvDL0/i5u/HC4VeWXB+w2LSSC63qWHwo+RkwfaJFLXKMO1JUWlQvxXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-color-alpha": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-swatch": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.10.3.tgz",
+      "integrity": "sha512-7Q/h9RTeloFnrIo/k6U5g+D/abSIT62FiAQZLaEC34O2eOtu1LQReTXAgx39b1HSQ8piCgBYaQc7oM9WhRTPow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-wheel": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-wheel/-/react-color-wheel-2.10.3.tgz",
+      "integrity": "sha512-eNFWioQt8Fr3UgHpuCxN4/gniZReOit3FzYxVFVXzQD5Hd6ch6jJDDZFFTl2NGVuTfsXLIepLYe9B5FHajC7AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.3",
+        "@uiw/react-drag-event-interactive": "2.10.3"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-drag-event-interactive": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@uiw/react-drag-event-interactive/-/react-drag-event-interactive-2.10.3.tgz",
+      "integrity": "sha512-veLm9HF1cairiYbGxcALYVu51T4XAzDz8fmtQ0SiLVFHBX74+iUGo2jArS/XALFBnapsLYTAWTnHXxe38mC/Vw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -9211,6 +9655,32 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colors-named": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/colors-named/-/colors-named-1.0.5.tgz",
+      "integrity": "sha512-xaspf9oddAOqP2LYNOgp8E3BwAzugrdO9J1kDNS5ySrzTgV9hrXGBt5w87ioLEr2pM4Ukt+GKedvzaLRxpv8pA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/colors-named-hex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/colors-named-hex/-/colors-named-hex-1.0.4.tgz",
+      "integrity": "sha512-X+Enw/2fFAgDRhUac69cRO/RJvHnWDBBrP8J1sJuEU16Buiiu8PPpJP4abSo0V+fJbkfwmQITE6zKx/SBJERGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -745,7 +745,7 @@
     "@gravity-ui/readme-validator": "^1.3.0",
     "@gravity-ui/stylelint-config": "^4.0.1",
     "@gravity-ui/tsconfig": "^1.0.0",
-    "@gravity-ui/uikit": "^7.25.0",
+    "@gravity-ui/uikit": "^7.48.3",
     "@playwright/experimental-ct-react": "^1.56.1",
     "@playwright/test": "^1.56.1",
     "@storybook/addon-docs": "^9.0.5",

--- a/playwright/core/expectScreenshotFixture.ts
+++ b/playwright/core/expectScreenshotFixture.ts
@@ -41,6 +41,12 @@ export const expectScreenshotFixture: PlaywrightFixture<ExpectScreenshotFixture>
         // Wait for loading fonts
         await page.evaluate(() => document.fonts.ready);
 
+        // Wait for the entrance transition of the mounted uikit overlays. They fade in from
+        // `opacity: 0`, and Playwright already reports a fully transparent node as visible, so an
+        // assertion like `expect(dialog).toBeVisible()` does not hold the capture back on its own.
+        const overlays = await page.locator('.g-modal:visible, .g-popup:visible').all();
+        await Promise.all(overlays.map((overlay) => expect(overlay).toHaveCSS('opacity', '1')));
+
         expect(await captureScreenshot()).toMatchSnapshot({
             name: `${nameScreenshot}.png`,
         });

--- a/src/components/atoms/SubmitButton/SubmitButton.scss
+++ b/src/components/atoms/SubmitButton/SubmitButton.scss
@@ -16,7 +16,12 @@ $block: '.#{variables.$ns}submit-button';
         display: flex;
     }
 
+    // uikit 7.48 moved the spinner colour from `--g-color-line-brand` to its own
+    // `--g-spin-color`, so both have to be set while the peer range spans versions before and
+    // after that change. Without it the spinner keeps the brand colour of the button it sits on
+    // and becomes invisible.
     &__spinner {
         --g-color-line-brand: var(--g-color-text-brand-contrast);
+        --g-spin-color: var(--g-color-text-brand-contrast);
     }
 }

--- a/src/components/templates/History/__tests__/History.visual.spec.tsx
+++ b/src/components/templates/History/__tests__/History.visual.spec.tsx
@@ -142,6 +142,10 @@ test.describe('History', {tag: '@History'}, () => {
 
         await page.getByRole('button').click();
         await page.locator('.g-aikit-history__container').waitFor({state: 'visible'});
+        // Hovering while the popup is still fading in makes Chromium decide the item is not fully
+        // visible and scroll it into view, which leaves the list offset by the height of the first
+        // date group for the rest of the test and cuts that group off the screenshot.
+        await expect(page.locator('.g-popup').first()).toHaveCSS('opacity', '1');
 
         await page.locator('.g-aikit-history__chat-item').first().hover();
         const deleteButton = page.locator('.g-aikit-history__delete-button').first();
@@ -167,6 +171,10 @@ test.describe('History', {tag: '@History'}, () => {
 
         await page.getByRole('button').click();
         await page.locator('.g-aikit-history__container').waitFor({state: 'visible'});
+        // Hovering while the popup is still fading in makes Chromium decide the item is not fully
+        // visible and scroll it into view, which leaves the list offset by the height of the first
+        // date group for the rest of the test and cuts that group off the screenshot.
+        await expect(page.locator('.g-popup').first()).toHaveCSS('opacity', '1');
 
         await page.locator('.g-aikit-history__chat-item').first().hover();
         await page.locator('.g-aikit-history__delete-button').first().click();

--- a/src/hooks/useMobileControlSize.ts
+++ b/src/hooks/useMobileControlSize.ts
@@ -1,6 +1,8 @@
 import {useMobile} from '@gravity-ui/uikit';
 
-export type ControlSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+// `xxs` only exists on `Label`, which uikit 7.48 gained. It is listed here so that the helpers
+// stay usable with the whole `LabelProps['size']` union across the supported uikit range.
+export type ControlSize = 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl';
 
 /**
  * Resolves a control size: an explicit size always wins, otherwise the mobile


### PR DESCRIPTION
The dev dependency resolved to `7.25.0`, the very bottom of the supported peer range, so the visual tests only ever saw the oldest markup uikit ships. That is how the sheet title regression fixed in #244 reached a release: the test that covers it is markup agnostic, but the rename it guards against simply never happened in the test run.

This raises the resolution to `7.48.3`. The peer range stays at `^7.25.0` — both markups have to keep working.

## Regressions the bump uncovered

Same pattern each time: aikit reaches for an internal uikit class or CSS variable from the outside, and uikit renamed it.

**The submit button spinner became invisible.** uikit 7.48 moved the spinner colour out of `--g-color-line-brand` into its own `--g-spin-color`, with `--g-color-base-brand` as the fallback. The `SubmitButton` override stopped applying, so the spinner took the brand colour of the button it sits on. Both variables are set now, the unused one is ignored on either version.

**`tsc` failed.** uikit 7.48 added `xxs` to `LabelProps['size']`, which no longer fits the `ControlSize` constraint of the size helpers, so `ContextItem` stopped typechecking. Note that a plain `npm run typecheck` against the newer version would have caught this one, no browser needed.

## Snapshots

**None of the 346 snapshots had to be re-recorded.** Once the two regressions above are fixed, everything recorded on 7.25 still matches on 7.48.3.

Full suite at the CI settings (`--workers=1 --retries=2`, cold Vite cache): **421 passed, 0 flaky, 0 failed.**

## Two flaky screenshot races fixed along the way

**Overlay entrance transitions.** uikit overlays fade in from `opacity: 0`, and Playwright already reports a fully transparent node as visible, so `expect(dialog).toBeVisible()` released the capture mid-transition and an empty page ended up in the shot. On 7.48 that failed 13 of 36 runs of the `@InputContext`, `@AttachmentPicker` and `@FileUploadDialog` specs, a different subset each time. Waiting for the mounted overlays to reach `opacity: 1` first takes it to 0 of 150.

**The `History` delete tests scrolled themselves.** Hovering a chat item while the popup is still fading in makes Chromium decide the item is not fully visible and scroll it into view. That scrolls the inner list by the height of the first date group and the page by 78px, and the list keeps that offset for the rest of the test, so the group is cut off the screenshot.

This one is **older than this branch** — measured with `--workers=1 --repeat-each=8`, same command both times:

| | `should show trash button…` | `should remove deleted chat…` |
|---|---|---|
| `main`, uikit 7.25 | 0/8 fail | **2/8 fail** |
| bump only, uikit 7.48.3 | 1/8 fail | 8/8 fail |
| with the fix | 0/8 | 0/8 |

The failing pixel count on `main` is 9026 — byte for byte the same figure the bump produces, and the same visual defect. 7.48 only widens the window, because its popup gained a transform transition. `retries: 2` on CI has been hiding it all along. Waiting for the popup to reach `opacity: 1` before the first hover takes both tests to 0 of 20 under parallel load.

## Two things noticed nearby, both left alone

- `expect.toHaveScreenshot.maxDiffPixelRatio: 0.02` in `playwright-ct.config.ts` is dead — the fixture compares buffers through `toMatchSnapshot`, which does not read that setting, so comparison is effectively pixel exact. Switching to `toHaveScreenshot` would activate the 2% tolerance, and that tolerance would have masked the invisible spinner above (0.18% of pixels).
- `playwright/.cache` can serve stale compiled SCSS between runs. Clear it before any run whose result depends on a fresh `.scss` edit.

## Should the visual tests run as a matrix?

Three regressions of the same shape in one bump argue for it, but not for a full matrix. The snapshots matching across 7.25 and 7.48 was luck — the rendering barely moved. On the next redesign a matrix means two sets of references, doubling both the run time and the cost of every re-record.

A cheaper split: run `typecheck`, the unit tests and the behavioural CT assertions (`toBeHidden`, `toHaveText`, `toHaveCount`) against the **minimum** supported version, and keep the full snapshot suite on the **maximum** only. Those behavioural assertions are exactly what catches renames — the hidden sheet title test would have failed immediately under that setup.

Separately, since all three breakages hung off private uikit selectors and variables (`.g-sheet__*`, `--g-color-line-brand`), a short list of those hooks in `docs/guidelines/` would make it clear what to re-check by hand on the next bump.

## Verification

- Visual: 421 passed, 0 flaky, 0 failed (cold cache, CI settings)
- `npm run typecheck`, `npm run lint`, `npm run build`: clean
- Unit: 284 + 19 passed
- Control runs: reverting the `#244` mixin makes both sheet title tests fail on `toBeHidden()` (the node is present, `display: block`, class `g-sheet-content-area__content-title`; the old `.g-sheet__sheet-content-title` is absent). Reverting `--g-spin-color` makes the two `SubmitButton` snapshots fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
